### PR TITLE
elf, output-handler: Include unistd.h required by close() and sleep()

### DIFF
--- a/src/elf.cc
+++ b/src/elf.cc
@@ -7,6 +7,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <libelf.h>
 #include <dwarf.h>
 #include <elfutils/libdw.h>

--- a/src/output-handler.cc
+++ b/src/output-handler.cc
@@ -9,6 +9,7 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <signal.h>
 #include <dirent.h>
 #include <pthread.h>


### PR DESCRIPTION
This is a fix for compilation failure reported in issue #6.
