### PR TITLE
Add --original-path and --new-path command line options

### DIFF
--- a/src/include/configuration.hh
+++ b/src/include/configuration.hh
@@ -54,7 +54,8 @@ namespace kcov
 		virtual std::map<unsigned int,std::string> &getExcludePath() = 0;
 
 		virtual enum OutputType getOutputType() = 0;
-
+		virtual const std::string& getNewPathPrefix() = 0;
+		virtual const std::string& getOriginalPathPrefix() = 0;
 		virtual void setOutputType(enum OutputType) = 0;
 
 		virtual bool parse(unsigned int argc, const char *argv[]) = 0;


### PR DESCRIPTION
Update the configuration.cc, configuration.hh, and elf.cc files to add command line options that allow kcov to find the source code in a different directory from the information contained in the binary.
