### PR TITLE
Add -lz to the linker flags to fix linking error.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,13 +80,15 @@ target_link_libraries(${KCOV}
 	${LIBELF_LIBRARIES}
 	stdc++
 	dl
-	pthread)
+	pthread
+	z)
 
 target_link_libraries(${KCOV_PROFILER}
 	${LIBDWARF_LIBRARIES}
 	${LIBELF_LIBRARIES}
 	stdc++
 	dl
-	pthread)
+	pthread
+	z)
 
 install (TARGETS ${PROJECT_NAME} ${INSTALL_TARGETS_PATH})


### PR DESCRIPTION
Not sure if i'm doing something wrong, but linking process fails for me with the following error:

`Linking CXX executable kcov
/usr/local/lib64/libdw.a(dwarf_begin_elf.o): In function `check_section.isra.1':
(.text+0x1de): undefined reference to `inflateInit_'
/usr/local/lib64/libdw.a(dwarf_begin_elf.o): In function `check_section.isra.1':
(.text+0x217): undefined reference to `inflate'
/usr/local/lib64/libdw.a(dwarf_begin_elf.o): In function `check_section.isra.1':
(.text+0x22a): undefined reference to `inflateReset'
/usr/local/lib64/libdw.a(dwarf_begin_elf.o): In function `check_section.isra.1':
(.text+0x244): undefined reference to `inflateEnd'`

This patch fixes the issue for me.
