### PR TITLE
Support specifying the installation RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}
                         ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package (PkgConfig REQUIRED)
 
+set (SPECIFY_RPATH OFF CACHE BOOL "Specify RPATH for installed executables")
 
 # ====================================
 # default install paths for targets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,17 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/bin-to-c-source.py
    )
 
+# Reference: http://www.cmake.org/Wiki/CMake_RPATH_handling
+if(SPECIFY_RPATH)
+	set (CMAKE_SKIP_BUILD_RPATH  FALSE)
+	set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+	set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+	# the RPATH to be used when installing, but only if it's not a system directory
+	LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+	IF("${isSystemDir}" STREQUAL "-1")
+	  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+	ENDIF("${isSystemDir}" STREQUAL "-1")
+endif(SPECIFY_RPATH)
 
 add_executable (${KCOV} ${${KCOV}_SRCS} library.cc python-helper.cc html-data-files.cc)
 add_executable (${LINE2ADDR} ${${LINE2ADDR}_SRCS})


### PR DESCRIPTION
Hi Simon,

This patch adds the capability to specify the installation RPATH when building kcov.

The use case for this is where kcov is being built using a newer g++ version (due to C++11 usage) and then deployed to another machine that doesn't have the newer libstdc++ library available in the expected location (without having to set LD_LIBRARY_PATH).

Example usage:
cd kcov
mkdir build
cd build
cmake -DSPECIFY_RPATH=TRUE -DCMAKE_INSTALL_PREFIX=/local/testsuite
make
make install

The installed version of the kcov executables have the RPATH set to include $CMAKE_INSTALL_PREFIX/lib.
