### PR TITLE
Fixes an exception with 1- or 2-letter-long executable names.

### DIFF
--- a/src/engines/bash-engine.cc
+++ b/src/engines/bash-engine.cc
@@ -326,7 +326,7 @@ public:
 	{
 		std::string s((const char *)data, 80);
 
-		if (filename.substr(filename.size() - 3, filename.size()) == ".sh")
+		if (filename.size() >= 3 && filename.substr(filename.size() - 3, filename.size()) == ".sh")
 			return 200;
 
 		if (s.find("#!/bin/bash") != std::string::npos)
@@ -626,7 +626,7 @@ public:
 	{
 		std::string s((const char *)data, 80);
 
-		if (filename.substr(filename.size() - 3, filename.size()) == ".sh")
+		if (filename.size() >= 3 && filename.substr(filename.size() - 3, filename.size()) == ".sh")
 			return 200;
 
 		if (s.find("#!/bin/bash") != std::string::npos)

--- a/src/engines/python-engine.cc
+++ b/src/engines/python-engine.cc
@@ -196,7 +196,7 @@ public:
 	{
 		std::string s((const char *)data, 80);
 
-		if (filename.substr(filename.size() - 3, filename.size()) == ".py")
+		if (filename.size() >= 3 && filename.substr(filename.size() - 3, filename.size()) == ".py")
 			return 200;
 
 		if (s.find("python") != std::string::npos)
@@ -444,7 +444,7 @@ public:
 	{
 		std::string s((const char *)data, 80);
 
-		if (filename.substr(filename.size() - 3, filename.size()) == ".py")
+		if (filename.size() >= 3 && filename.substr(filename.size() - 3, filename.size()) == ".py")
 			return 200;
 
 		if (s.find("python") != std::string::npos)


### PR DESCRIPTION
Fixes #72.

I'm not sure how to test this though, any advice is welcomed.