### PR TITLE
Add initial support for position-independent executables.

### DIFF
--- a/src/engines/script-engine-base.hh
+++ b/src/engines/script-engine-base.hh
@@ -50,6 +50,11 @@ public:
 		return true;
 	}
 
+	bool setMainFileRelocation(unsigned long relocation)
+	{
+		return true;
+	}
+
 	void registerLineListener(ILineListener &listener)
 	{
 		m_lineListeners.push_back(&listener);

--- a/src/include/file-parser.hh
+++ b/src/include/file-parser.hh
@@ -147,6 +147,22 @@ namespace kcov
 		virtual bool addFile(const std::string &filename, struct phdr_data_entry *phdr_data = 0) = 0;
 
 		/**
+		 * Set the relocation of the main file for the position-independent executable (PIE) support
+		 *
+		 * PIEs have, like shared objects, an unknown load address which can only be
+		 * retrieved from the solib handler. Because of this the parser may defer
+		 * onFile and onLine notifications before this call.
+		 *
+		 * This method, if any, should be called after the initial parse call and
+		 * beefore the following addFile calls for solibs.
+		 *
+		 * @param relocation relocation offset
+		 *
+		 * @return true if the relocation is properly set, false otherwise
+		 */
+		virtual bool setMainFileRelocation(unsigned long relocation) = 0;
+
+		/**
 		 * Register a listener for source lines.
 		 *
 		 * Will be called when new source file/line pairs are found

--- a/src/include/phdr_data.h
+++ b/src/include/phdr_data.h
@@ -27,6 +27,7 @@ struct phdr_data
 {
 	uint32_t magic;
 	uint32_t version;
+	unsigned long relocation; // for PIE
 	uint32_t n_entries;
 
 	struct phdr_data_entry entries[];

--- a/src/merge-file-parser.cc
+++ b/src/merge-file-parser.cc
@@ -95,6 +95,11 @@ public:
 		return true;
 	}
 
+	virtual bool setMainFileRelocation(unsigned long relocation)
+	{
+		return true;
+	}
+
 	virtual void registerLineListener(IFileParser::ILineListener &listener)
 	{
 		m_lineListeners.push_back(&listener);

--- a/src/solib-handler.cc
+++ b/src/solib-handler.cc
@@ -195,6 +195,8 @@ public:
 		if (!p)
 			return;
 
+		m_parser->setMainFileRelocation(p->relocation);
+
 		for (unsigned int i = 0; i < p->n_entries; i++)
 		{
 			struct phdr_data_entry *cur = &p->entries[i];

--- a/src/solib-parser/lib.c
+++ b/src/solib-parser/lib.c
@@ -20,6 +20,12 @@ static struct phdr_data *phdr_data;
 
 static int phdrCallback(struct dl_phdr_info *info, size_t size, void *data)
 {
+	// the first entry is used to determine the executable's "base address"
+	// (which is actually the relocation for PIE)
+	if (phdr_data->n_entries == 0) {
+		phdr_data->relocation = info->dlpi_addr;
+	}
+
 	phdr_data_add(phdr_data, info);
 
 	return 0;

--- a/src/solib-parser/phdr_data.c
+++ b/src/solib-parser/phdr_data.c
@@ -10,7 +10,7 @@
 #include <link.h>
 
 #define KCOV_MAGIC         0x6b636f76 /* "kcov" */
-#define KCOV_SOLIB_VERSION 2
+#define KCOV_SOLIB_VERSION 3
 
 static uint8_t data_area[4 * 1024 * 1024];
 
@@ -23,6 +23,7 @@ struct phdr_data *phdr_data_new(size_t allocSize)
 
 	p->magic = KCOV_MAGIC;
 	p->version = KCOV_SOLIB_VERSION;
+	p->relocation = 0;
 	p->n_entries = 0;
 
 	return p;


### PR DESCRIPTION
What an appropriate PR for [pi(e) day](https://en.wikipedia.org/wiki/Pi_Day), heh. :) Anyway, this PR adds two features that enable the support for position-independent executables:

* Disables the address randomization after fork. While this does not directly enable PIE support (AFAIK, x86_64 Linux always relocates the PIE at 0x555555554000) this should help any potential issues from ASLR.
* Reads the "base address" (or more accurately, relocation) of PIE from `solib_wrapper`. This has some design implications, and I went to the easiest way possible: DWARF parsing is deferred until `solib_wrapper` returns. I think we already have to wait for that, so this should not be a big problem.

Again with the prior PR, I haven't written a proper test case for this. (I tried to run test cases, but I'm blocked on pybot downloads...) Any executable compiled with `gcc -pie -fpie -fPIE` should work.