### PR TITLE
Fixed build fail on python3 default machines

### DIFF
--- a/src/bin-to-c-source.py
+++ b/src/bin-to-c-source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, struct
 


### PR DESCRIPTION
kcov was failing on my Arch Linux machine, which defaults `/usr/bin/env python` to python3.

This makes it more explicit that python2 is needed