### PR TITLE
fix python version in travis makefile

### DIFF
--- a/travis/Makefile
+++ b/travis/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make
 
 chroot=/tmp/32-bit-chroot
-kcov_deps=libdw-dev libelf-dev elfutils libcurl4-openssl-dev python3 cmake binutils-dev
+kcov_deps=libdw-dev libelf-dev elfutils libcurl4-openssl-dev python cmake binutils-dev
 
 .PHONY: prepare_environment
 


### PR DESCRIPTION
without python2, build fails here:

https://github.com/SimonKagstrom/kcov/blob/6ac673df3e141b28971f506d476de5b1b63ed229/src/bin-to-c-source.py#L1

```
/usr/bin/env: python2: No such file or directory
make[2]: *** [src/library.cc] Error 127
make[2]: *** Waiting for unfinished jobs....
[ 16%] /usr/bin/env: python2: No such file or directory
make[2]: *** [src/bash-redirector-library.cc] Error 127
```