### PR TITLE
Exit with status 0 when printing version.

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -221,7 +221,7 @@ public:
 				break;
 			case 'v':
 				printf("kcov %s\n", kcov_version);
-				exit(1);
+				exit(0);
 				break;
 			case 'L':
 				setKey("parse-solibs", 0);


### PR DESCRIPTION
Printing the version string is very useful for build scripts, specially on continuous integration set ups. Exiting with non-zero status mean an error happened which is not the case.