### PR TITLE
support setting strip path mamuly

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -80,6 +80,7 @@ public:
 				"\n"
 				" --coveralls-id=id       Travis CI job ID or secret repo_token for uploads to\n"
 				"                         Coveralls.io\n"
+				" --strip-path=path       If not set, max common path will be stripped away.\n"
 				"%s"
 				"\n"
 				"Examples:\n"
@@ -120,6 +121,7 @@ public:
 				{"exclude-path", required_argument, 0, 'X'},
 				{"include-path", required_argument, 0, 'I'},
 				{"coveralls-id", required_argument, 0, 'T'},
+				{"strip-path", required_argument, 0, 'Z'},
 				{"debug", required_argument, 0, 'D'},
 				{"debug-force-bash-stderr", no_argument, 0, 'd'},
 				{"bash-handle-sh-invocation", no_argument, 0, 's'},
@@ -305,6 +307,9 @@ public:
 				break;
 			case 'T':
 				setKey("coveralls-id", optarg);
+				break;
+			case 'Z':
+				setKey("strip-path", std::string(optarg));
 				break;
 			case 'x':
 				setKey("exclude-pattern", getCommaSeparatedList(std::string(optarg)));
@@ -494,6 +499,7 @@ public:
 		setKey("output-interval", 5000);
 		setKey("daemonize-on-first-process-exit", 0);
 		setKey("coveralls-id", "");
+		setKey("strip-path", "");
 		setKey("orig-path-prefix", "");
 		setKey("new-path-prefix", "");
 		setKey("running-mode", IConfiguration::MODE_COLLECT_AND_REPORT);

--- a/src/writers/coveralls-writer.cc
+++ b/src/writers/coveralls-writer.cc
@@ -158,6 +158,12 @@ public:
 		}
 		out << " \"source_files\": [\n";
 		setupCommonPaths();
+		
+		std::string strip_path = conf.keyAsString("strip-path");
+		if (strip_path.size() == 0) {
+			setupCommonPaths();
+			strip_path = m_commonPath + "/";
+		}
 
 		unsigned int filesLeft = m_files.size();
 		for (FileMap_t::const_iterator it = m_files.begin();
@@ -166,9 +172,9 @@ public:
 			File *file = it->second;
 			std::string fileName;
 
-			// Strip away the common path (unless this is the only file)
-			if (m_commonPath != file->m_name)
-				fileName = file->m_name.substr(m_commonPath.size() + 1);
+			// Strip away the specified path (unless this is the only file)
+			if (file->m_name.compare(0, strip_path.length(), strip_path) == 0)
+				fileName = file->m_name.substr(strip_path.size());
 			else
 				fileName = file->m_fileName;
 

--- a/tests/unit-tests/tests-configuration.cc
+++ b/tests/unit-tests/tests-configuration.cc
@@ -102,6 +102,11 @@ TESTSUITE(configuration)
 
 		ASSERT_TRUE(conf->keyAsList("exclude-pattern").size() == 1U);
 		ASSERT_TRUE(conf->keyAsList("exclude-pattern")[0] == "d/e/f");
+		
+		res = runParse(fmt("--strip-path=path"));
+		ASSERT_TRUE(res);
+		
+		ASSERT_TRUE(conf.keyAsString("strip-path") == "path");
 
 		res = runParse(fmt("--include-path=~/a /tmp/vobb %s", filename.c_str()));
 		ASSERT_TRUE(res);


### PR DESCRIPTION
Currently when uploading coverage data to coveralls.io, common path will be tripped away, which may lead to source not found error when you want to check the coverage data of a single file. For example, if using following command to collect coverage:

```
kcov --include-patten projectname/src --coveralls-id ${TRAVIS_JOB_ID} target/kcov path/to/executable
```

file *projectname/src/main.c* will be stripped as *main.c*, but coveralls.io requires *src/main.c* to be able to fetch source code from github.