### PR TITLE
Ignore build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.order
 *.mod.c
 kcov
+build


### PR DESCRIPTION
In my shell, I use [git-prompt.sh](https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh) with the `GIT_PS1_SHOWUNTRACKEDFILES` option enabled. While iterating on this repo, my shell looks like this:

```sh
kcov (master %=) $
```

...indicating an untracked file(s). This PR makes git stop telling me about an untracked file while working here.