### PR TITLE
Add `libiberty-dev` to ubuntu install help

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ elfutils-devel and *not* elfutils-libelf-devel.
 
 Ubuntu
 ------
-Install binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev
+Install binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev
 
 
 Fedora / Centos / RHEL


### PR DESCRIPTION
In order to use the `--verify` flag, the `libiberty-dev` package seems to be necessary when compiling kcov on some versions of ubuntu.

In my desktop version of ubuntu 16.10, its unnecessary. However, in the docker image `buildpack:yakkety`, the package is not installed by default.