### PR TITLE
bash-engine: Check stdout readable before getline

### DIFF
--- a/tests/bash/handle-all-output.sh
+++ b/tests/bash/handle-all-output.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+for ((i=0; i != 1000; ++i)); do
+  echo "$i"
+done

--- a/tests/tools/bash.py
+++ b/tests/tools/bash.py
@@ -235,14 +235,23 @@ class bash_eof_backtick(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 180) == 1
 
 class bash_subshell(testbase.KcovTestCase):
-    @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
         rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/subshell.sh")
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/subshell.sh/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "subshell.sh", 1) == None
-        assert parse_cobertura.hitsPerLine(dom, "subshell.sh", 4) == 2
-        assert parse_cobertura.hitsPerLine(dom, "subshell.sh", 8) == None
+        self.assertIsNone(parse_cobertura.hitsPerLine(dom, "subshell.sh", 1))
+        self.assertEqual(2, parse_cobertura.hitsPerLine(dom, "subshell.sh", 4))
+        self.assertEqual(0, parse_cobertura.hitsPerLine(dom, "subshell.sh", 8))
+
+class bash_handle_all_output(testbase.KcovTestCase):
+    def runTest(self):
+        script = "handle-all-output.sh"
+        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " +
+            testbase.sources + "/tests/bash/" + script,
+            timeout=5.0)
+        self.assertEqual(0, rv, "kcov exited unsuccessfully")
+        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/" + script + "/cobertura.xml")
+        self.assertIsNone(parse_cobertura.hitsPerLine(dom, script, 1))
+        self.assertEqual(1000, parse_cobertura.hitsPerLine(dom, script, 4))
 
 class bash_exit_status(testbase.KcovTestCase):
     @unittest.expectedFailure


### PR DESCRIPTION
Pull SimonKagstrom/kcov#193 (written to resolve SimonKagstrom/kcov#192) caused the [mbland/go-script-bash](https://github.com/mbland/go-script-bash) Travis build to fail. That build clones SimonKagstrom/kcov each time, and after that pull request, kcov began hanging after printing the number of Bats test cases on Linux, e.g.:

-  https://travis-ci.org/mbland/go-script-bash/jobs/246933167

This change resolves the issue by calling `file_readable` on standard output before calling `getline`.

Though I don't have a perfect understanding yet, it appears that Bash scripts that run for some amount of time and produce some amount of standard output eventually end up blocking when trying to write. Previously, when the parent `kcov` process would subsequently block in `getline`, the child process running the Bash script somehow wasn't able to resume, implying some sort of deadlock.

At any rate, the new `bash_handle_all_output` test case reliably reproduces the failure and validates the fix. It required adding a timeout capability to `KcovTestCase.do`.

I've also removed `@unittest.expectedFailure` from `bash_subshell`, as it isn't necessary and it confirms that the behavior implemented by SimonKagstrom/kcov#193 remains intact.