### PR TITLE
build: Avoid packaging man dir with cpack

### DIFF
--- a/CPack.local.cmake
+++ b/CPack.local.cmake
@@ -18,4 +18,8 @@ set (CPACK_SOURCE_IGNORE_FILES
   .*~  .*.log
 )
 
+set (CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
+    /usr/share/man /usr/share/man/man1
+    /usr/local/share/man /usr/local/share/man/man1)
+
 include (CPack)


### PR DESCRIPTION
Packaging the man dir breaks installation on most distributions.
Avoid packaging normal man dirs. Conflicts may still occur on
non-standard installation paths (not /usr or /usr/local).