### PR TITLE
ptrace: tie_process_to_cpu: allocate cpu_set_t big enough to accomodate cpu

### DIFF
--- a/src/engines/ptrace.cc
+++ b/src/engines/ptrace.cc
@@ -137,7 +137,7 @@ static void tie_process_to_cpu(pid_t pid, int cpu)
 	// Switching CPU while running will cause icache
 	// conflicts. So let's just forbid that.
 
-	int max_cpu = cpu + 1;
+	int max_cpu = 4096;
 	cpu_set_t *set = CPU_ALLOC(max_cpu);
 	panic_if (!set,
 			"Can't allocate CPU set!\n");

--- a/src/engines/ptrace.cc
+++ b/src/engines/ptrace.cc
@@ -137,12 +137,13 @@ static void tie_process_to_cpu(pid_t pid, int cpu)
 	// Switching CPU while running will cause icache
 	// conflicts. So let's just forbid that.
 
-	cpu_set_t *set = CPU_ALLOC(1);
+	int max_cpu = cpu + 1;
+	cpu_set_t *set = CPU_ALLOC(max_cpu);
 	panic_if (!set,
 			"Can't allocate CPU set!\n");
-	CPU_ZERO_S(CPU_ALLOC_SIZE(1), set);
+	CPU_ZERO_S(CPU_ALLOC_SIZE(max_cpu), set);
 	CPU_SET(cpu, set);
-	panic_if (sched_setaffinity(pid, CPU_ALLOC_SIZE(1), set) < 0,
+	panic_if (sched_setaffinity(pid, CPU_ALLOC_SIZE(max_cpu), set) < 0,
 			"Can't set CPU affinity. Coincident won't work");
 	CPU_FREE(set);
 }


### PR DESCRIPTION
Fixes: [240](https://github.com/SimonKagstrom/kcov/issues/240)

Problem: if the cpu number is bigger than the chunk size the kernel uses
for allocating the affinity mask, `sched_setaffinity` fails with `EINVAL`
and kcov exits on panic.
Solution: allocate a cpu_set large enough for the the specified cpu to
fit, forcing a sufficiently large mask.

Testing done: instrumented and ran in a loop

```diff
@@ -137,13 +137,18 @@ static void tie_process_to_cpu(pid_t pid, int cpu)
        // Switching CPU while running will cause icache
        // conflicts. So let's just forbid that.
 
-       int max_cpu = cpu + 1;
+       int max_cpu = cpu + 1, ret = -1;
        cpu_set_t *set = CPU_ALLOC(max_cpu);
        panic_if (!set,
                        "Can't allocate CPU set!\n");
        CPU_ZERO_S(CPU_ALLOC_SIZE(max_cpu), set);
        CPU_SET(cpu, set);
-       panic_if (sched_setaffinity(pid, CPU_ALLOC_SIZE(max_cpu), set) < 0,
+       ret = sched_setaffinity(pid, CPU_ALLOC_SIZE(max_cpu), set);
+       if (ret < 0)
+                fprintf(stderr, "ERR tie_process_to_cpu pid %d cpu %d retcode %d errno %d : %s\n", pid, cpu, ret, errno, strerror(errno));
+       else
+                fprintf(stdout, "OK tie_process_to_cpu pid %d cpu %d retcode %d\n", pid, cpu, ret);
+       panic_if(ret < 0,
                        "Can't set CPU affinity. Coincident won't work");
        CPU_FREE(set);
 }
```

Before:
```bash
OK tie_process_to_cpu pid 70355 cpu 21 retcode 0
OK tie_process_to_cpu pid 70405 cpu 55 retcode 0
OK tie_process_to_cpu pid 70408 cpu 19 retcode 0
OK tie_process_to_cpu pid 70410 cpu 19 retcode 0
OK tie_process_to_cpu pid 70410 cpu 19 retcode 0
OK tie_process_to_cpu pid 70454 cpu 55 retcode 0
ERR tie_process_to_cpu pid 70486 cpu 70 retcode -1 errno 22 : Invalid argument
kcov: error: Can't set CPU affinity. Coincident won't work
```

After:
```bash
OK tie_process_to_cpu pid 16239 cpu 62 retcode 0
OK tie_process_to_cpu pid 16293 cpu 25 retcode 0
OK tie_process_to_cpu pid 16295 cpu 25 retcode 0
OK tie_process_to_cpu pid 16295 cpu 25 retcode 0
OK tie_process_to_cpu pid 16296 cpu 71 retcode 0
OK tie_process_to_cpu pid 16298 cpu 71 retcode 0
OK tie_process_to_cpu pid 16328 cpu 28 retcode 0
```