### PR TITLE
ptrace: include elf.h for NT_PRSTATUS

### DIFF
--- a/src/engines/ptrace.cc
+++ b/src/engines/ptrace.cc
@@ -21,6 +21,7 @@
 
 #if defined(__aarch64__)
 #  include <sys/uio.h>
+#  include <elf.h>
 #endif
 
 #include <map>


### PR DESCRIPTION
In order to build on NixOS I had to add the following include on top of https://github.com/SimonKagstrom/kcov/pull/239.

`<elf.h>` was the least terrifying header in which `NT_PRSTATUS` appears defined in glibc 2.26-131. `<linux/ptrace.h>` had a more appropriate name, but being in the `<linux/` namespace I thought `<elf.h>` was a better pick.

Logs [before](https://logs.nix.ci/?key=nixos/nixpkgs.39624&attempt_id=0342d4c4-c880-47a9-b125-1bed464b92e1) and [after](https://logs.nix.ci/?key=nixos/nixpkgs.39624&attempt_id=49ea1849-53ca-4e37-bfed-177fb427ce7d), I don't have much more than that as testing goes :)