### PR TITLE
Various CMake and CPack fixes/improvements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ cmake_minimum_required (VERSION 2.6)
 # ====================================
 project (kcov)
 
+if(POLICY CMP0042)
+  # MACOSX_RPATH is enabled by default.
+  cmake_policy (SET CMP0042 NEW)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE  Release)
 endif(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ cmake_minimum_required (VERSION 2.6)
 # ====================================
 project (kcov)
 
+set (PROJECT_VERSION_MAJOR 35)
+set (PROJECT_VERSION_MINOR 0)
+set (PROJECT_VERSION_PATCH 0)
+set (PROJECT_VERSION
+     "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+
 if(POLICY CMP0042)
   # MACOSX_RPATH is enabled by default.
   cmake_policy (SET CMP0042 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ add_definitions(-DPACKAGE_VERSION)
 # configuring
 # ====================================
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-find_package (PkgConfig REQUIRED)
 
 set (SPECIFY_RPATH OFF CACHE BOOL "Specify RPATH for installed executables")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,13 @@ if(POLICY CMP0042)
   cmake_policy (SET CMP0042 NEW)
 endif()
 
-if(NOT CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE  Release)
-endif(NOT CMAKE_BUILD_TYPE)
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set (CMAKE_BUILD_TYPE Release CACHE STRING
+       "Choose the type of build, options are None Debug Release RelWithDebInfo MinSizeRel"
+       FORCE)
+  set_property (CACHE CMAKE_BUILD_TYPE PROPERTY
+                STRINGS None Debug Release RelWithDebInfo MinSizeRel)
+endif (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 
 add_definitions(-DPACKAGE)
 add_definitions(-DPACKAGE_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,7 @@ add_definitions(-DPACKAGE_VERSION)
 # ====================================
 # configuring
 # ====================================
-set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}
-                        ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package (PkgConfig REQUIRED)
 
 set (SPECIFY_RPATH OFF CACHE BOOL "Specify RPATH for installed executables")

--- a/CPack.local.cmake
+++ b/CPack.local.cmake
@@ -22,4 +22,8 @@ set (CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
     /usr/share/man /usr/share/man/man1
     /usr/local/share/man /usr/local/share/man/man1)
 
+set (CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+set (CPACK_DEBIAN_PACKAGE_HOMEPAGE https://simonkagstrom.github.io/kcov/)
+
 include (CPack)

--- a/cmake/FindElfutils.cmake
+++ b/cmake/FindElfutils.cmake
@@ -16,9 +16,18 @@ if (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
   set (LibDwarf_FIND_QUIETLY TRUE)
 endif (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
 
+find_package(PkgConfig QUIET)
+
+if(PKG_CONFIG_FOUND)
+  set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
+  pkg_check_modules(PC_LIBDW QUIET libdw)
+endif()
+
 find_path (DWARF_INCLUDE_DIR
     NAMES
       dwarf.h
+    HINTS
+      ${PC_LIBDW_INCLUDE_DIRS}
     PATHS
       /usr/include
       /usr/local/include
@@ -28,6 +37,8 @@ find_path (DWARF_INCLUDE_DIR
 find_path (LIBDW_INCLUDE_DIR
     NAMES
       elfutils/libdw.h
+    HINTS
+      ${PC_LIBDW_INCLUDE_DIRS}
     PATHS
       /usr/include
       /usr/local/include
@@ -41,6 +52,8 @@ endif (DWARF_INCLUDE_DIR AND LIBDW_INCLUDE_DIR)
 find_library (LIBDW_LIBRARY
     NAMES
       dw
+    HINTS
+      ${PC_LIBDW_LIBRARY_DIRS}
     PATHS
       /usr/lib
       /usr/local/lib

--- a/cmake/FindLibElf.cmake
+++ b/cmake/FindLibElf.cmake
@@ -13,14 +13,22 @@
 #  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
 
-
 if (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
   set (LibElf_FIND_QUIETLY TRUE)
 endif (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
 
+find_package(PkgConfig QUIET)
+
+if(PKG_CONFIG_FOUND)
+  set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
+  pkg_check_modules(PC_LIBELF QUIET libelf)
+endif()
+
 find_path (LIBELF_INCLUDE_DIR
     NAMES
       libelf.h
+    HINTS
+      ${PC_LIBELF_INCLUDE_DIRS}
     PATHS
       /usr/include
       /usr/include/libelf
@@ -35,6 +43,8 @@ find_path (LIBELF_INCLUDE_DIR
 find_library (LIBELF_LIBRARY
     NAMES
       elf
+    HINTS
+      ${PC_LIBELF_LIBRARY_DIRS}
     PATHS
       /usr/lib
       /usr/local/lib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,12 @@ cmake_minimum_required (VERSION 2.6)
 # ====================================
 project (kcov)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+if(POLICY CMP0042)
+  # MACOSX_RPATH is enabled by default.
+  cmake_policy (SET CMP0042 NEW)
+endif()
+
 find_package (Threads)
 find_package (Bfd)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -342,7 +342,7 @@ if (LIBELF_FOUND)
 		dl
 		${LLDB_LIBRARY}
 	)
-	install (TARGETS ${KCOV} ${INSTALL_TARGETS_PATH})
+	install (TARGETS ${KCOV} DESTINATION ${INSTALL_TARGETS_PATH})
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES Linux)
@@ -355,5 +355,5 @@ if (${CMAKE_SYSTEM_NAME} MATCHES Linux)
         ${CMAKE_THREAD_LIBS_INIT}
         dl
 	)
-	install (TARGETS kcov-system-daemon ${INSTALL_TARGETS_PATH})
+	install (TARGETS kcov-system-daemon DESTINATION ${INSTALL_TARGETS_PATH})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required (VERSION 2.6)
 
 project (kcov)
-set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}
-                        ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
+list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 find_package (Threads)
 find_package (Bfd)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -243,9 +243,6 @@ include_directories(
 	)
 endif()
 
-
-link_directories (/home/ska/local/lib)
-
 add_library (bash_execve_redirector SHARED engines/bash-execve-redirector.c)
 set_target_properties(bash_execve_redirector PROPERTIES SUFFIX ".so")
 target_link_libraries(bash_execve_redirector dl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required (VERSION 2.6)
 
+# ====================================
+# project name and version
+# ====================================
 project (kcov)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 find_package (Threads)
@@ -12,10 +15,6 @@ message(STATUS "Target architectures: ${CMAKE_TARGET_ARCHITECTURES}")
 find_package (ZLIB REQUIRED)
 find_package (CURL)
 
-# ====================================
-# project name and version
-# ====================================
-project (kcov)
 set (KCOV kcov)
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ else()
         "/usr/local/lib64"
         "/opt/local/lib"
         "/opt/usr/lib64"
+		"/Library/Developer/CommandLineTools/Library/PrivateFrameworks"
 		"/Applications/Xcode.app/Contents/SharedFrameworks"
 		ENV LIBRARY_PATH
 		ENV LD_LIBRARY_PATH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,8 +9,8 @@ include(TargetArch)
 target_architecture(CMAKE_TARGET_ARCHITECTURES)
 message(STATUS "Target architectures: ${CMAKE_TARGET_ARCHITECTURES}")
 
-pkg_check_modules(LIBZ REQUIRED zlib)
-pkg_check_modules(LIBCURL libcurl)
+find_package (ZLIB REQUIRED)
+find_package (CURL)
 
 # ====================================
 # project name and version
@@ -68,14 +68,14 @@ endif()
 
 set (coveralls_SRCS writers/dummy-coveralls-writer.cc)
 
-if (LIBCURL_FOUND)
+if (CURL_FOUND)
 	set (coveralls_SRCS writers/coveralls-writer.cc)
 endif()
 
 if ("${KCOV_STATIC_BUILD}" STREQUAL "1")
 	message(STATUS "Building a static binary (no coveralls support)")
 
-	set (LIBCURL_LIBRARIES "")
+	set (CURL_LIBRARIES "")
 	# Coveralls doesn't work in a static setting
 	set (coveralls_SRCS writers/dummy-coveralls-writer.cc)
 	set (CMAKE_EXE_LINKER_FLAGS "-static")
@@ -217,7 +217,7 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -g -Wall -D_GLIBCXX_USE_NANO
 include_directories(
 	include/
 	../external/lldb/include/
-	${LIBZ_INCLUDE_DIRS}
+	${ZLIB_INCLUDE_DIR}
 	)
 
 if (LIBDW_FOUND)
@@ -232,9 +232,9 @@ include_directories(
 	)
 endif()
 
-if (LIBCURL_FOUND)
+if (CURL_FOUND)
 include_directories(
-	${LIBCURL_INCLUDE_DIRS}
+	${CURL_INCLUDE_DIRS}
 	)
 endif()
 
@@ -247,7 +247,7 @@ target_link_libraries(bash_execve_redirector dl)
 
 add_library (kcov_system_lib SHARED engines/system-mode-binary-lib.cc utils.cc system-mode/registration.cc)
 set_target_properties(kcov_system_lib PROPERTIES SUFFIX ".so")
-target_link_libraries(kcov_system_lib dl ${LIBZ_LIBRARIES})
+target_link_libraries(kcov_system_lib dl ${ZLIB_LIBRARIES})
 
 
 add_custom_command(
@@ -335,10 +335,10 @@ if (LIBELF_FOUND)
 		${LIBDW_LIBRARIES}
 		${LIBELF_LIBRARIES}
 		stdc++
-		${LIBCURL_LIBRARIES}
+		${CURL_LIBRARIES}
 		m
 		${DISASSEMBLER_LIBRARIES}
-		${LIBZ_LIBRARIES}
+		${ZLIB_LIBRARIES}
 		${CMAKE_THREAD_LIBS_INIT}
 		dl
 		${LLDB_LIBRARY}
@@ -352,7 +352,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES Linux)
     target_link_libraries(kcov-system-daemon
         stdc++
         m
-        ${LIBZ_LIBRARIES}
+        ${ZLIB_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
         dl
 	)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -81,8 +81,6 @@ include_directories(
 	${LIBDW_INCLUDE_DIRS}
 	)
 
-link_directories (/home/ska/local/lib)
-
 add_executable (${TGT} ${${TGT}_SRCS} html-data-files.cc)
 
 target_link_libraries(${TGT}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package (LibElf REQUIRED)
 find_package (Elfutils REQUIRED)
 find_package (PkgConfig REQUIRED)
 find_package (Threads)
-pkg_check_modules(LIBZ REQUIRED zlib)
+find_package (ZLIB REQUIRED)
 
 # ====================================
 # project name and version
@@ -34,7 +34,7 @@ include_directories(
 	../src/include/
 	${LIBELF_INCLUDE_DIRS}
 	${LIBDW_INCLUDE_DIRS}
-	${LIBZ_INCLUDE_DIRS}
+	${ZLIB_INCLUDE_DIR}
 )
 
 # Reference: http://www.cmake.org/Wiki/CMake_RPATH_handling
@@ -58,7 +58,7 @@ target_link_libraries(${LINE2ADDR}
 	dl
 	${CMAKE_THREAD_LIBS_INIT}
 	m
-	${LIBZ_LIBRARIES})
+	${ZLIB_LIBRARIES})
 
 file ( GLOB kcov-merge kcov-merge )
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required (VERSION 2.6)
 
 project (kcov-tools)
-set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}
-                        ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
+list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 find_package (LibElf REQUIRED)
 find_package (Elfutils REQUIRED)
 find_package (PkgConfig REQUIRED)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required (VERSION 2.6)
 
 project (kcov-tools)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+if(POLICY CMP0042)
+  # MACOSX_RPATH is enabled by default.
+  cmake_policy (SET CMP0042 NEW)
+endif()
+
 find_package (LibElf REQUIRED)
 find_package (Elfutils REQUIRED)
 find_package (PkgConfig REQUIRED)


### PR DESCRIPTION
PTAL @SimonKagstrom. We could simplify the build further if we required CMake 3.0 (circa 2014) rather than 2.6 (circa 2008).