### PR TITLE
Correct external licenses

### DIFF
--- a/COPYING.externals
+++ b/COPYING.externals
@@ -1,3 +1,3 @@
-handlebars.js: BSD
-tablesorter (mottie): GPL/MIT
+handlebars.js: MIT
+tablesorter (mottie): GPLv2 or MIT
 jquery: MIT


### PR DESCRIPTION
handlebars.js is MIT-licensed, not BSD.  AFAICT, it always has been.

Clarify that tablesorter is dual licensed under the GPLv2 or MIT.

https://github.com/wycats/handlebars.js/blob/master/LICENSE
https://github.com/Mottie/tablesorter/blob/master/README.md#licensing