### PR TITLE
Fix false bash line count on function with spaces between name and parenthesis

### DIFF
--- a/src/engines/bash-engine.cc
+++ b/src/engines/bash-engine.cc
@@ -647,6 +647,11 @@ private:
 			// fn() { .... Yes, regexes would have been better
 			size_t fnPos = s.find("()");
 			if (fnPos != std::string::npos) {
+				// Trim valid last spaces between function name and parenthesis
+				while (fnPos > 1 && ' ' == s[fnPos - 1]) {
+					--fnPos;
+				}
+
 				std::string substr = s.substr(0, fnPos);
 
 				// Should be a single word (the function name)

--- a/tests/bash/function-with-spaces.sh
+++ b/tests/bash/function-with-spaces.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#!/bin/sh
+#function-with-spaces.sh
+
+fun1() {
+    echo "hello"
+}
+
+fun2 ()
+{
+    echo "world"
+}
+
+#
+# Main
+#
+
+fun1
+fun2

--- a/tests/tools/bash.py
+++ b/tests/tools/bash.py
@@ -310,3 +310,14 @@ class bash_can_ignore_non_executed_scripts(testbase.KcovTestCase):
         # Not included in report
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 3) == None
+
+class bash_can_ignore_function_with_spaces(testbase.KcovTestCase):
+    def runTest(self):
+        rv,o = self.do(testbase.kcov + " --bash-dont-parse-binary-dir " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/function-with-spaces.sh")
+
+        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/function-with-spaces.sh/cobertura.xml")
+        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 5) == None
+        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 6) == 1
+        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 9) == None
+        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 10) == None
+        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 11) == 1


### PR DESCRIPTION
```fn()``` was not evaluated as executable line, but ```fn ()``` was.