### PR TITLE
Code coverage report behind nginx/1.15.0 can not show well which respose index.json as application/json

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -10,7 +10,7 @@
 <font color=red><B>ERROR:</B></font> JavaScript need to be enabled for the coverage report to work.
 </noscript>
 
-<script type="text/javascript" src="index.json"></script>
+<script type="text/javascript" src="index.js"></script>
 <script type="text/javascript" src="data/js/jquery.min.js"></script>
 <script type="text/javascript" src="data/js/tablesorter.min.js"></script>
 <script type="text/javascript" src="data/js/jquery.tablesorter.widgets.min.js"></script>

--- a/src/writers/html-writer.cc
+++ b/src/writers/html-writer.cc
@@ -141,7 +141,7 @@ private:
 		unsigned int nTotalCodeLines = 0;
 
 		// Out-file for JSON data
-		std::ofstream outJson(m_outDirectory + "index.json");
+		std::ofstream outJson(m_outDirectory + "index.js");
 		outJson << "var data = {files:[\n"; // Not really json, but anyway
 
 		for (FileMap_t::const_iterator it = m_files.begin();
@@ -233,7 +233,7 @@ private:
 		dir = opendir(idx.c_str());
 		panic_if(!dir, "Can't open directory %s\n", idx.c_str());
 
-		std::ofstream outJson(m_indexDirectory + "index.json");
+		std::ofstream outJson(m_indexDirectory + "index.js");
 
 		outJson << "var data = {files:[\n";
 		std::string merged;

--- a/src/writers/writer-base.cc
+++ b/src/writers/writer-base.cc
@@ -56,7 +56,7 @@ WriterBase::File::File(const std::string &filename) :
 	readFile(filename);
 
 	m_outFileName = fmt("%s.%x.html", m_fileName.c_str(), m_crc);
-	m_jsonOutFileName = fmt("%s.%x.json", m_fileName.c_str(), m_crc);
+	m_jsonOutFileName = fmt("%s.%x.js", m_fileName.c_str(), m_crc);
 }
 
 void WriterBase::File::readFile(const std::string &filename)


### PR DESCRIPTION

The develop console output：

```
Loading failed for the <script> with source “https://.../master/test_sh/index.json”
ReferenceError: data is not defined[Learn More] kcov.js:41:3
```

When I check the response data， an error output:

```
SyntaxError: JSON.parse: unexpected end of data at line 1 column 1 of the JSON data
```

Change file name to .js fix this problem. Cloud we change the file extension to fit the real file type?