### PR TITLE
Better guide for Mac OS X in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,10 +32,10 @@ Create an empty build dir and do the following steps:
 ```
   cd <build-dir>
   cmake -G Xcode <path/to/kcov/source/dir>
-  xcodebuild -configuration Release
+  xcodebuild -target kcov -configuration Release
 ```
 
-The binary will be in `src/Release/kcov`
+The binary will be `src/Release/kcov`
 
 Building
 ========


### PR DESCRIPTION
The target for `xcodebuild` should be explicitly specified, otherwise `kcov` binary won't exist at the noted path.

Complete guide for my team looks and works as follows:
```
brew install jq zlib bash cmake pkgconfig
cd $HOME
wget https://github.com/SimonKagstrom/kcov/archive/v36.tar.gz
tar -xvf ./v36.tar.gz
rm ./v36.tar.gz
cd $HOME/kcov-36
cmake -G Xcode
xcodebuild -target kcov -configuration Release
chmod a+x $HOME/kcov-36/src/Release/kcov
echo "export PATH=\"$HOME/kcov-36/src/Release/:\$PATH:\"" >> ~/.bash_profile
```