### PR TITLE
Handle the bash version properly to support non-English and bash 5.0

### DIFF
--- a/src/engines/bash-engine.cc
+++ b/src/engines/bash-engine.cc
@@ -462,7 +462,7 @@ private:
 		FILE *fp;
 		bool out = false;
 		IConfiguration &conf = IConfiguration::getInstance();
-		std::string cmd = conf.keyAsString("bash-command") + " --version";
+		std::string cmd = conf.keyAsString("bash-command") + " -c 'echo \"$BASH_VERSION\"'";
 
 		/* Has input via stderr been forced regardless of bash version?
 		 * Basically for testing only
@@ -474,25 +474,14 @@ private:
 		if (!fp)
 			return false;
 
+		int major = 0;
+		int minor = 0;
+
 		// Read the first line
-		char *line = NULL;
-		ssize_t len;
-		size_t linecap = 0;
-
-		len = getline(&line, &linecap, fp);
-		// Let's play safe
-		if (len > 0)
-		{
-			std::string cur(line);
-			size_t where = cur.find("version ");
-			if (where != std::string::npos)
-			{
-				std::string versionStr = cur.substr(where + strlen("version "));
-
-				// Bash 4.2 and above supports BASH_XTRACEFD
-				if (versionStr.size() > 4 && versionStr[0] >= '4' && versionStr[2] >= '2')
-					out = true;
-			}
+		if (fscanf(fp, "%d.%d", &major, &minor) != EOF) {
+			// Bash 4.2 and above supports BASH_XTRACEFD
+			if (major > 4 || (major == 4 && minor >= 2))
+				out = true;
 		}
 
 		pclose(fp);


### PR DESCRIPTION
(I tested on Ubuntu 18.04, bash 4.4.19 and Ubuntu 19.04, bash 5.0.3)

First, I noticed that the `BASH_XTRACEFD` revert to `2` when `LANG=ja_JP.UTF-8`.


```sh
# xtracedfd.sh
echo $BASH_XTRACEFD > /dev/tty
```

```console
$ LANG=C kcov /tmp/out/ xtracedfd.sh
782

$ LANG=C bash --version
GNU bash, version 4.4.19(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

```console
$ LANG=ja_JP.UTF-8 kcov /tmp/out/ xtracedfd.sh
2

$ LANG=ja_JP.UTF-8 bash --version
GNU bash, バージョン 4.4.19(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2016 Free Software Foundation, Inc.
ライセンス GPLv3+: GNU GPL バージョン 3 またはそれ以降 <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

When `LANG=ja_JP.UTF-8`, `bash --version` was translated into Japanese, and the string of `version` is not displayed.

`bashCanHandleXtraceFd()` function find for the string `version`, so version can not be detected.
https://github.com/SimonKagstrom/kcov/blob/af13dcc42d12bd78599cd53dced6ebacaa7626dc/src/engines/bash-engine.cc#L460-L501

Second, I noticed that this code can not handle bash version 5.0. (e.g. `5.0.3(1)-release`)
https://github.com/SimonKagstrom/kcov/blob/af13dcc42d12bd78599cd53dced6ebacaa7626dc/src/engines/bash-engine.cc#L492-L495

I currently use `kcov --bash-method=DEBUG` as workaround for this problem.

This pull request handle the bash version properly to support non-English and bash 5.0.
