### PR TITLE
Enable functrace

### DIFF
--- a/src/engines/bash-helper-debug-trap.sh
+++ b/src/engines/bash-helper-debug-trap.sh
@@ -1,4 +1,4 @@
- #!/bin/sh
+#!/bin/sh
 
 set -o functrace
 trap 'echo "kcov@${BASH_SOURCE}@${LINENO}@" >&$KCOV_BASH_XTRACEFD' DEBUG

--- a/src/engines/bash-helper-debug-trap.sh
+++ b/src/engines/bash-helper-debug-trap.sh
@@ -1,4 +1,5 @@
  #!/bin/sh
 
+set -o functrace
 trap 'echo "kcov@${BASH_SOURCE}@${LINENO}@" >&$KCOV_BASH_XTRACEFD' DEBUG
 unset BASH_ENV


### PR DESCRIPTION
Enable `functrace` shell option to cover in function when using `--bash-method=DEBUG`

Require this option to inherit DEBUG trap in shell function. `functrace` was introduced in bash 3.0. 

I think this PR can close #234.

And I found probably unnecessary leading space.
