### PR TITLE
Parse correctly the tracing line of PS4

### DIFF
--- a/src/engines/bash-engine.cc
+++ b/src/engines/bash-engine.cc
@@ -256,19 +256,18 @@ public:
 		std::string cur(curLine);
 		// Line markers always start with kcov@
 
-		size_t kcovStr = cur.find("kcov@");
-		enum InputType ip = getInputType(cur);
-		if (kcovStr == std::string::npos)
-		{
-			if (m_inputType == INPUT_NORMAL)
-				fprintf(stderr, "%s", cur.c_str());
-			if (ip == INPUT_SINGLE_QUOTE && m_inputType == INPUT_SINGLE_QUOTE)
-				m_inputType = INPUT_NORMAL;
-
+		if (m_inputType == INPUT_SINGLE_QUOTE) {
+			m_inputType = getInputType(cur);
 			return true;
 		}
 
-		m_inputType = ip;
+		size_t kcovStr = cur.find("kcov@");
+		if (kcovStr == std::string::npos)
+		{
+			fprintf(stderr, "%s", cur.c_str());
+			return true;
+		}
+		m_inputType = getInputType(cur);
 
 		std::vector<std::string> parts = split_string(cur.substr(kcovStr), "@");
 
@@ -501,12 +500,14 @@ private:
 
 	enum InputType getInputType(const std::string &str)
 	{
-		enum InputType out = INPUT_NORMAL;
+		enum InputType out = m_inputType;
 
-		size_t singleQuotes = std::count(str.begin(), str.end(), '\'');
-
-		if (singleQuotes == 1)
-			out = INPUT_SINGLE_QUOTE;
+		for(std::string::size_type i = 0; i < str.size(); ++i) {
+			if (str[i] == '\\' && out == INPUT_NORMAL)
+				i++;
+			else if (str[i] == '\'')
+				out = (out == INPUT_NORMAL ? INPUT_SINGLE_QUOTE : INPUT_NORMAL);
+		}
 
 		return out;
 	}


### PR DESCRIPTION
This PR fixes unexpected output to stderr when using `--bash-method=PS4`

[test.sh]
```sh
#!/bin/sh

a='line1\'\''
line2'

if [ "$a" ]; then
  :
fi
```

```console
$ kcov /tmp/cover ./test.sh >/dev/null
line2'
line2' ']'
```


I think it works correctly but there is no test. I do not know where to write the test. How can I check if it is broken?

By the way, I found this problem during develop [shellspec](https://github.com/shellspec/shellspec) - new BDD testing framewrok for shell script. Unexpected output to stderr caused failure the tests via shellspec. I managed to integrate kcov using `--bash-method=DEBUG` (with workaround for #303). kcov is a great software! thanks!

