### PR TITLE
Avoid unversioned python shebangs

### DIFF
--- a/src/bin-to-c-source.py
+++ b/src/bin-to-c-source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 

--- a/src/engines/python-helper.py
+++ b/src/engines/python-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 
 # Based on http://pymotw.com/2/sys/tracing.html, "Tracing a program as it runs"

--- a/tests/multi-fork/generate-functions.py
+++ b/tests/multi-fork/generate-functions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/tests/python/main
+++ b/tests/python/main
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import second

--- a/tests/tools/parse_cobertura.py
+++ b/tests/tools/parse_cobertura.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import xml.dom.minidom

--- a/tests/tools/run-tests
+++ b/tests/tools/run-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import unittest

--- a/tests/tools/testbase.py
+++ b/tests/tools/testbase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import unittest
 import os


### PR DESCRIPTION
Starting with Fedora 31 plain python means Python 3 and it wouldn't be
surprising that other operating systems gradually make the same change
as Python 2 is going EOL.

Refs #305