### PR TITLE
 Convert src scripts to Python 3 

### DIFF
--- a/src/bin-to-c-source.py
+++ b/src/bin-to-c-source.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python2
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import sys, struct
 

--- a/src/engines/python-helper.py
+++ b/src/engines/python-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # encoding: utf-8
 
 # Based on http://pymotw.com/2/sys/tracing.html, "Tracing a program as it runs"

--- a/tests/tools/bash.py
+++ b/tests/tools/bash.py
@@ -36,7 +36,6 @@ class bash_coverage(testbase.KcovTestCase):
 
 # Very limited, will expand once it's working better
 class bash_coverage_debug_trap(testbase.KcovTestCase):
-    @unittest.expectedFailure
     def runTest(self):
         self.setUp()
         rv,o = self.do(testbase.kcov + " --bash-method=DEBUG " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main 5")


### PR DESCRIPTION
Both scripts were already python3-ready so only their shebang changes
here. In particular, Python 2 support in python-helper.py was not yet
removed since Python 2 is not EOL quite yet.

Fixes #305