### PR TITLE
Update for latest debian stable (buster) docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 Dockerfile
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM debian:stable AS builder
+FROM debian:stable-slim AS builder
 
 RUN apt-get update && \
-    apt-get install -y --fix-missing pkg-config && \
     apt-get install -y \
         binutils-dev \
         build-essential \
@@ -11,46 +10,31 @@ RUN apt-get update && \
         libdw-dev \
         libiberty-dev \
         ninja-build \
-        python \
+        python3 \
         zlib1g-dev \
         ;
 
 ADD . /src/
 
-RUN mkdir -p /src/build && \
+RUN mkdir /src/build && \
     cd /src/build && \
     cmake -G 'Ninja' .. && \
     cmake --build . && \
     cmake --build . --target install
 
-# ensure we don't copy any unneeded libs into final image
-RUN apt-get purge -y \
-        binutils-dev \
-        build-essential \
-        cmake \
-        git \
-        libcurl4-openssl-dev \
-        libdw-dev \
-        libiberty-dev \
-        ninja-build \
-        python \
-        zlib1g-dev \
-        && \
-    apt-get autoremove -y && \
-    apt-get autoclean -y
+FROM debian:stable-slim
 
 RUN apt-get update && \
     apt-get install -y \
         binutils \
-        libcurl3 \
+        libcurl4 \
         libdw1 \
         zlib1g \
-        ;
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-FROM debian:stable-slim
-COPY --from=builder /lib/x86_64-linux-gnu/*.so* /lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/*.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/local/bin/kcov* /usr/local/bin/
-COPY --from=builder /usr/local/share/doc/kcov /usr/local/chare/doc/kcov
+COPY --from=builder /usr/local/share/doc/kcov /usr/local/share/doc/kcov
 
 CMD ["/usr/local/bin/kcov"]


### PR DESCRIPTION
Feel free to use it if you want.

- Use debian:stable-slim for builder.
- Remove --fix-missing pkg-config (unnecessary?).
- Update to python3 and libcurl4.
- Do not copy libs (reduce image size 203MB -> 117MB).
- Add /src/build to .dockerignore to do not add unnecessary files.
- Fix typo (/usr/local/chare/doc/kcov -> /usr/local/share/doc/kcov).
