### PR TITLE
Unpack struct file_data

### DIFF
--- a/src/merge-file-parser.cc
+++ b/src/merge-file-parser.cc
@@ -43,7 +43,7 @@ struct file_data
 	uint32_t file_name_offset;
 
 	struct line_entry entries[];
-}__attribute__((packed));
+};
 
 // Unit test stuff
 namespace merge_parser


### PR DESCRIPTION
Packing the structure brings no benefit on 32bit systems and plugs a
marginal hole of 4 bytes on 64bit architectures. It also creates a
misaligned starting point for the entries[] flex array at the end and
while this is typically not a problem for x86 it is reported by GCC
with the address-of-packed-member warning.

Closes #311