### PR TITLE
Avoid hang on aarch64

### DIFF
--- a/src/engines/ptrace.cc
+++ b/src/engines/ptrace.cc
@@ -44,7 +44,11 @@ static unsigned long arch_setupBreakpoint(unsigned long addr, unsigned long old_
 #elif defined(__arm__)
 	val = 0xfedeffe7; // Undefined insn
 #elif defined(__aarch64__)
-	val = 0xd4200000;
+	unsigned long aligned_addr = getAligned(addr);
+	unsigned long offs = addr - aligned_addr;
+	unsigned long shift = 8 * offs;
+
+	val = (old_data & ~(0xffffffffUL << shift)) | (0xd4200000UL << shift);
 #else
 # error Unsupported architecture
 #endif

--- a/src/engines/ptrace_linux.cc
+++ b/src/engines/ptrace_linux.cc
@@ -19,7 +19,7 @@
 
 enum
 {
-	i386_EIP = 12, x86_64_RIP = 16, ppc_NIP = 32, arm_PC = 15, aarch64_PC = 33, // See Linux arch/arm64/include/asm/ptrace.h
+	i386_EIP = 12, x86_64_RIP = 16, ppc_NIP = 32, arm_PC = 15, aarch64_PC = 32, // See Linux arch/arm64/include/asm/ptrace.h
 };
 
 static void arch_adjustPcAfterBreakpoint(unsigned long *regs);


### PR DESCRIPTION
I believe this fixes #267 and should make kcov usable on aarch64.
