### PR TITLE
Issue #323: bash engine: drain stdout of instrumented script

### DIFF
--- a/src/include/utils.hh
+++ b/src/include/utils.hh
@@ -122,6 +122,15 @@ extern int concat_files(const char *dst, const char *file_a, const char *file_b)
 extern const char *get_home();
 
 /**
+ * Make a FILE * non blocking when not enough data can be read from it
+ *
+ * @param fp the file to read
+ *
+ * @return true if the file could be made non blocking, false otherwise
+ */
+bool make_file_non_blocking(FILE *fp);
+
+/**
  * Return true if a FILE * is readable without blocking.
  *
  * @param fp the file to read

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -271,6 +271,16 @@ const char *get_home(void)
 	return getenv("HOME");
 }
 
+bool make_file_non_blocking(FILE *fp)
+{
+	int fd = fileno(fp);
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (flags == -1)
+		return false;
+	else
+		return fcntl(fd, F_SETFL, flags | O_NONBLOCK) != -1;
+}
+
 bool file_readable(FILE *fp, unsigned int ms)
 {
 	fd_set rfds;

--- a/tests/bash/long-output-without-return.sh
+++ b/tests/bash/long-output-without-return.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+for ((i=0; i != 32768; ++i)); do
+  printf "%04x" $RANDOM
+done

--- a/tests/tools/bash.py
+++ b/tests/tools/bash.py
@@ -324,3 +324,13 @@ class bash_can_ignore_function_with_spaces(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 9) == None
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 10) == None
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 11) == 1
+
+class bash_drain_stdout_without_return(testbase.KcovTestCase):
+    def runTest(self):
+        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " +
+            testbase.sources + "/tests/bash/long-output-without-return.sh",
+            timeout=5.0)
+        self.assertEqual(0, rv, "kcov exited unsuccessfully")
+        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/long-output-without-return.sh/cobertura.xml")
+        self.assertIsNone(parse_cobertura.hitsPerLine(dom, "long-output-without-return.sh", 1))
+        self.assertEqual(32768, parse_cobertura.hitsPerLine(dom, "long-output-without-return.sh", 4))


### PR DESCRIPTION
When bash supports xtrace fd, no kcov marker can come from the
instrumented script's stdout, so it's safe to drain it as soon
as data is written to it, without waiting for '\n'.

stdout writers: Sum code/executed lines before generating headers