### PR TITLE
Issue #325: bash-engine: new option to not leak trace fd to children

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,6 +298,10 @@ add_library (bash_execve_redirector SHARED engines/bash-execve-redirector.c)
 set_target_properties(bash_execve_redirector PROPERTIES SUFFIX ".so")
 target_link_libraries(bash_execve_redirector ${DL_LIBRARY})
 
+add_library (bash_tracefd_cloexec SHARED engines/bash-tracefd-cloexec.c)
+set_target_properties(bash_tracefd_cloexec PROPERTIES SUFFIX ".so")
+target_link_libraries(bash_tracefd_cloexec ${DL_LIBRARY})
+
 add_library (kcov_system_lib SHARED engines/system-mode-binary-lib.cc utils.cc system-mode/registration.cc)
 set_target_properties(kcov_system_lib PROPERTIES SUFFIX ".so")
 target_link_libraries(kcov_system_lib
@@ -324,6 +328,17 @@ add_custom_command(
         > bash-redirector-library.cc
     DEPENDS
         bash_execve_redirector
+        "${CMAKE_CURRENT_SOURCE_DIR}/bin-to-c-source.py"
+)
+
+add_custom_command(
+    OUTPUT bash-cloexec-library.cc
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/bin-to-c-source.py"
+            $<TARGET_FILE:bash_tracefd_cloexec>
+            bash_cloexec_library
+        > bash-cloexec-library.cc
+    DEPENDS
+        bash_tracefd_cloexec
         "${CMAKE_CURRENT_SOURCE_DIR}/bin-to-c-source.py"
 )
 
@@ -406,7 +421,7 @@ if (SPECIFY_RPATH)
 endif (SPECIFY_RPATH)
 
 if (LIBELF_FOUND)
-	add_executable (${KCOV} ${${KCOV}_SRCS} ${SOLIB_generated} bash-redirector-library.cc python-helper.cc bash-helper.cc kcov-system-library.cc html-data-files.cc version.c)
+	add_executable (${KCOV} ${${KCOV}_SRCS} ${SOLIB_generated} bash-redirector-library.cc bash-cloexec-library.cc python-helper.cc bash-helper.cc kcov-system-library.cc html-data-files.cc version.c)
 
 	target_link_libraries(${KCOV}
 		stdc++

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -137,6 +137,7 @@ public:
 		{ "debug", required_argument, 0, 'D' },
 		{ "debug-force-bash-stderr", no_argument, 0, 'd' },
 		{ "bash-handle-sh-invocation", no_argument, 0, 's' },
+		{ "bash-tracefd-cloexec", no_argument, 0, 't' },
 		{ "bash-dont-parse-binary-dir", no_argument, 0, 'j' },
 		{ "bash-parse-files-in-dirs", required_argument, 0, 'J' },
 		{ "replace-src-path", required_argument, 0, 'R' },
@@ -376,6 +377,9 @@ public:
 			case 's':
 				setKey("bash-handle-sh-invocation", 1);
 				break;
+			case 't':
+				setKey("bash-tracefd-cloexec", 1);
+				break;
 			case '4':
 			{
 				std::string s(optarg);
@@ -598,6 +602,7 @@ public:
 		setKey("include-path", StrVecMap_t());
 		setKey("bash-force-stderr-input", 0);
 		setKey("bash-handle-sh-invocation", 0);
+		setKey("bash-tracefd-cloexec", 0);
 		setKey("bash-use-basic-parser", 0);
 		setKey("bash-use-ps4", 1);
 		setKey("bash-parse-file-dir", StrVecMap_t());
@@ -726,6 +731,8 @@ public:
 						" --bash-method=method    Bash coverage collection method, PS4 (default) or DEBUG\n"
 						" --bash-handle-sh-invocation  Try to handle #!/bin/sh scripts by a LD_PRELOAD\n"
 						"                         execve replacement. Buggy on some systems\n"
+						" --bash-tracefd-cloexec  Force children to not be traced by configuring the trace\n"
+						"                         fd as non-cloneable with LD_PRELOAD. Buggy on some systems\n"
 						" --bash-dont-parse-binary-dir Don't parse the binary directory for other scripts\n"
 						" --bash-parse-files-in-dir=dir[,...]  Parse bash scripts in dir(s)\n",
 				keyAsInt("path-strip-level"), keyAsInt("output-interval"),

--- a/src/engines/bash-tracefd-cloexec.c
+++ b/src/engines/bash-tracefd-cloexec.c
@@ -1,0 +1,28 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+
+void __attribute__((constructor)) tracefd_cloexec(void)
+{
+	int xtraceFd;
+	const char* fdStr;
+	char* endStr;
+
+	if (getenv("KCOV_BASH_USE_DEBUG_TRAP"))
+		fdStr = getenv("KCOV_BASH_XTRACEFD");
+	else
+		fdStr = getenv("BASH_XTRACEFD");
+
+	if (fdStr)
+	{
+		xtraceFd = (int)strtol(fdStr, &endStr, 10);
+		if (endStr != NULL && *endStr == '\0')
+		{
+			int flags = fcntl(xtraceFd, F_GETFD);
+			if (flags != -1)
+				fcntl(xtraceFd, F_SETFD, flags | FD_CLOEXEC);
+		}
+	}
+}

--- a/tests/bash/background-child.sh
+++ b/tests/bash/background-child.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+nohup sleep 6 &>/dev/null &
+echo leave child running

--- a/tests/tools/bash_linux_only.py
+++ b/tests/tools/bash_linux_only.py
@@ -10,3 +10,26 @@ class bash_sh_shebang(testbase.KcovTestCase):
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "sh-shebang.sh", 4) == 1
+
+class bash_exit_before_child(testbase.KcovTestCase):
+    def runTest(self):
+        # kcovKcov shouldn't wait for the background process, so call it with kcovKcov = False
+        rv,o = self.do(testbase.kcov + " --bash-tracefd-cloexec " + testbase.outbase + "/kcov " +
+            testbase.sources + "/tests/bash/background-child.sh",
+            kcovKcov = False,
+            timeout = 3.0,
+            kill = True)
+        self.assertEqual(0, rv, "kcov exited unsuccessfully")
+        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/background-child.sh/cobertura.xml")
+        self.assertIsNone(parse_cobertura.hitsPerLine(dom, "background-child.sh", 1))
+        self.assertEqual(1, parse_cobertura.hitsPerLine(dom, "background-child.sh", 3))
+        self.assertEqual(1, parse_cobertura.hitsPerLine(dom, "background-child.sh", 4))
+
+class bash_ldpreload_multilib(testbase.KcovTestCase):
+    def runTest(self):
+        rv,o = self.do(testbase.kcov + " --bash-handle-sh-invocation --bash-tracefd-cloexec " + testbase.outbase + "/kcov " +
+            testbase.sources + "/tests/bash/sh-shebang.sh")
+        self.assertEqual(0, rv, "kcov exited unsuccessfully")
+        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/sh-shebang.sh/cobertura.xml")
+        self.assertIsNone(parse_cobertura.hitsPerLine(dom, "sh-shebang.sh", 1))
+        self.assertEqual(1, parse_cobertura.hitsPerLine(dom, "sh-shebang.sh", 4))

--- a/tests/tools/testbase.py
+++ b/tests/tools/testbase.py
@@ -35,7 +35,7 @@ class KcovTestCase(unittest.TestCase):
 
         return rv, output
 
-    def do(self, cmdline, kcovKcov = True, timeout = None):
+    def do(self, cmdline, kcovKcov = True, timeout = None, kill = False):
         output = ""
         rv = 0
 
@@ -51,7 +51,10 @@ class KcovTestCase(unittest.TestCase):
         if timeout is not None:
             def stopChild():
                 print("\n  didn't finish within %s seconds; killing ..." % timeout)
-                child.terminate()
+                if kill:
+                    child.kill()
+                else:
+                    child.terminate()
 
             timer = threading.Timer(timeout, stopChild)
             timer.start()


### PR DESCRIPTION
When bash supports xtrace fd, a new option --bash-tracefd-cloexec
uses LD_PRELOAD to configure the trace fd to not be cloneable.
This is useful when e.g. the bash script spawns a daemon process
and does not want the trace fd to leak in the daemon.