### PR TITLE
Bash when root: set PS4 in bash-helper instead of the environment.

### DIFF
--- a/src/engines/bash-engine.cc
+++ b/src/engines/bash-engine.cc
@@ -221,12 +221,10 @@ public:
 
 			// Make a copy of the vector, now with "bash -x" first
 			char **vec;
-			int argcStart = usePS4 ? 2 : 1;
+			int argcStart = 1;
 			vec = (char **) xmalloc(sizeof(char *) * (argc + 3));
 			vec[0] = xstrdup(conf.keyAsString("bash-command").c_str());
 
-			if (usePS4)
-				vec[1] = xstrdup("-x");
 			for (unsigned i = 0; i < argc; i++)
 				vec[argcStart + i] = xstrdup(argv[i]);
 

--- a/src/engines/bash-engine.cc
+++ b/src/engines/bash-engine.cc
@@ -197,7 +197,6 @@ public:
 			{
 				doSetenv(fmt("BASH_ENV=%s", helperPath.c_str()));
 				doSetenv(fmt("BASH_XTRACEFD=%d", xtraceFd));
-				doSetenv("PS4=kcov@${BASH_SOURCE}@${LINENO}@");
 			}
 			else
 			{

--- a/src/engines/bash-helper.sh
+++ b/src/engines/bash-helper.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
+# Set PS4, the sh -x prompt.
+PS4='kcov@${BASH_SOURCE}@${LINENO}@'
+
 # Turn on tracing
 set -x


### PR DESCRIPTION
See #331 

The first commit is just there to prevent the line `PS4=...` in the helper to be printed when executed, which is inconvenient. There was no need to source the helper with -x, provided it sets -x anyway.