### PR TITLE
#314 ev_signal_exit returns m_exitCode

### DIFF
--- a/src/collector.cc
+++ b/src/collector.cc
@@ -135,7 +135,7 @@ private:
 						"kcov: binutils-dev), so the --verify option will not do anything."
 #endif
 						);
-
+			m_exitCode = ev.data;
 			break;
 
 		case ev_exit_first_process:


### PR DESCRIPTION
The exit code `m_exitCode` isn't set when crashing out with an `ev_signal_exit` so we don't pass the raised signal up.
By adding the same as the exit case, `m_exitCode = ev.data;` when a SEGFAULT is hit in the executed code kcov will return it to the caller.

This should resolve issue https://github.com/SimonKagstrom/kcov/issues/314