### PR TITLE
Allow a single address to map to multiple lines

### DIFF
--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -409,7 +409,7 @@ private:
 
 		for (LineList_t::iterator lit = it->second.begin();
                             lit != it->second.end();
-                            ++it) {
+                            ++lit) {
                         Line* line = *lit;
 
 			line->registerHit(addr, hits, m_maxPossibleHits != IFileParser::HITS_UNLIMITED);

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -340,7 +340,7 @@ private:
 		uint64_t lineId = line->lineId();
 
 		line->addAddress(addr);
-		m_addrToLine[addr] = line;
+		m_addrToLine[addr].push_back(line);
 		m_lineIdToFileMap[lineId] = line;
 
 		// Report pending addresses for this file/line
@@ -405,19 +405,19 @@ private:
 		if (it == m_addrToLine.end())
 			return;
 
-		kcov_debug(INFO_MSG, "REPORT hit at 0x%llx\n", (unsigned long long) addr);
-		Line *line = it->second;
+		kcov_debug(INFO_MSG, "REPORT hit at 0x%llx\n", (unsigned long long)addr);
 
-		line->registerHit(addr, hits, m_maxPossibleHits != IFileParser::HITS_UNLIMITED);
+		for (Line* line : it->second) {
+			line->registerHit(addr, hits, m_maxPossibleHits != IFileParser::HITS_UNLIMITED);
 
-		// Setup the hit order
-		if (line->getOrder() == 0)
-		{
-			line->setOrder(m_order);
-			m_order++;
+			// Setup the hit order
+			if (line->getOrder() == 0) {
+				line->setOrder(m_order);
+				m_order++;
+			}
+
+			reportAddress(line->lineId(), hits);
 		}
-
-		reportAddress(line->lineId(), hits);
 	}
 
 	// From IReporter::IListener - report recursively
@@ -719,7 +719,7 @@ private:
 	};
 
 	typedef std::unordered_map<std::string, File *> FileMap_t;
-	typedef std::unordered_map<uint64_t, Line *> AddrToLineMap_t;
+	typedef std::unordered_map<uint64_t, std::vector<Line *>> AddrToLineMap_t;
 	typedef std::unordered_map<uint64_t, unsigned long> AddrToHitsMap_t;
 	typedef std::vector<IReporter::IListener *> ListenerList_t;
 	typedef std::unordered_map<uint64_t, Line *> LineIdToFileMap_t;

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -405,9 +405,13 @@ private:
 		if (it == m_addrToLine.end())
 			return;
 
-		kcov_debug(INFO_MSG, "REPORT hit at 0x%llx\n", (unsigned long long)addr);
+		kcov_debug(INFO_MSG, "%p REPORT hit at 0x%llx\n", this, (unsigned long long)addr);
 
-		for (Line* line : it->second) {
+		for (LineList_t::iterator lit = it->second.begin();
+                            lit != it->second.end();
+                            ++it) {
+                        Line* line = *lit;
+
 			line->registerHit(addr, hits, m_maxPossibleHits != IFileParser::HITS_UNLIMITED);
 
 			// Setup the hit order
@@ -718,8 +722,9 @@ private:
 		unsigned long m_hits;
 	};
 
+	typedef std::vector<Line *> LineList_t;
 	typedef std::unordered_map<std::string, File *> FileMap_t;
-	typedef std::unordered_map<uint64_t, std::vector<Line *>> AddrToLineMap_t;
+	typedef std::unordered_map<uint64_t, LineList_t> AddrToLineMap_t;
 	typedef std::unordered_map<uint64_t, unsigned long> AddrToHitsMap_t;
 	typedef std::vector<IReporter::IListener *> ListenerList_t;
 	typedef std::unordered_map<uint64_t, Line *> LineIdToFileMap_t;


### PR DESCRIPTION
kcov currently only allows an address to be mapped to a single line.

Rust produces coverage information of the form:

```
[root@9cc0f19f33ac default_ignore]# readelf --debug-dump=decodedline target/debug/default_ignore-addf76c983f37444 | grep -A 20 "CU: src/lib.rs"
CU: src/lib.rs:
File name                            Line number    Starting address
lib.rs                                         8             0x1e480
lib.rs                                        10             0x1e480
```

kcov reads this information for `lib.rs:8`, and gets the mapping for `0x1e480` and creates a mapping and life is good.

It then reads the information for `lib.rs:10` and gets the mapping for `0x1e480`, and overwrites the mapping for `lib.rs:8` (leaking it in the process), and life is now not good.

To resolve this, I've tweaked kcov, so that it's address mapping is now a `std::map<uint64_t, std::vector<Line*>>` instead of just being a `std::map<uint64_t, Line*>`.