### PR TITLE
Fix build on gcc-13: add missing <stdint.h> include

### DIFF
--- a/src/include/collector.hh
+++ b/src/include/collector.hh
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include <stdint.h>
+
 namespace kcov
 {
 	class IFileParser;

--- a/src/include/reporter.hh
+++ b/src/include/reporter.hh
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <stddef.h>
+#include <stdint.h>
 
 namespace kcov
 {

--- a/src/include/source-file-cache.hh
+++ b/src/include/source-file-cache.hh
@@ -3,6 +3,8 @@
 #include <vector>
 #include <string>
 
+#include <stdint.h>
+
 namespace kcov
 {
 	/**


### PR DESCRIPTION
[ 15%] Building CXX object src/CMakeFiles/kcov.dir/writers/cobertura-writer.cc.o In file included from kcov/src/writers/cobertura-writer.cc:6: kcov/src/include/reporter.hh:24:90: error: 'uint64_t' has not been declared
   24 |      LineExecutionCount(unsigned int hits, unsigned int possibleHits, uint64_t order) :
      |                                                                       ^~~~~~~~