### PR TITLE
Add basic support for RISC-V architecture

### DIFF
--- a/src/engines/ptrace.cc
+++ b/src/engines/ptrace.cc
@@ -50,6 +50,8 @@ static unsigned long arch_setupBreakpoint(unsigned long addr, unsigned long old_
 	unsigned long shift = 8 * offs;
 
 	val = (old_data & ~(0xffffffffUL << shift)) | (0xd4200000UL << shift);
+#elif defined(__riscv)
+	val = 0x00100073; /* ebreak */ // No width problem, prefer ebreak than c.ebreak for ISA w/o C extension.
 #else
 # error Unsupported architecture
 #endif

--- a/src/engines/ptrace_linux.cc
+++ b/src/engines/ptrace_linux.cc
@@ -20,6 +20,7 @@
 enum
 {
 	i386_EIP = 12, x86_64_RIP = 16, ppc_NIP = 32, arm_PC = 15, aarch64_PC = 32, // See Linux arch/arm64/include/asm/ptrace.h
+	riscv_EPC = 0
 };
 
 static void arch_adjustPcAfterBreakpoint(unsigned long *regs);
@@ -40,7 +41,7 @@ static void arch_adjustPcAfterBreakpoint(unsigned long *regs)
 	regs[i386_EIP]--;
 #elif defined(__x86_64__)
 	regs[x86_64_RIP]--;
-#elif defined(__powerpc__) || defined(__arm__) || defined(__aarch64__)
+#elif defined(__powerpc__) || defined(__arm__) || defined(__aarch64__) || defined(__riscv)
 	// Do nothing
 #else
 # error Unsupported architecture
@@ -61,6 +62,8 @@ static unsigned long arch_getPcFromRegs(unsigned long *regs)
 	out = regs[aarch64_PC];
 #elif defined(__powerpc__)
 	out = regs[ppc_NIP];
+#elif defined(__riscv)
+	out = regs[riscv_EPC];
 #else
 # error Unsupported architecture
 #endif

--- a/src/solib-parser/lib.c
+++ b/src/solib-parser/lib.c
@@ -95,6 +95,8 @@ static void force_breakpoint(void)
 			".long 0xfedeffe7\n" /* undefined insn */
 #elif defined(__aarch64__)
 			".long 0xd4200000\n" /* From https://github.com/scottt/debugbreak */
+#elif defined(__riscv)
+			"ebreak\n"
 #else
 # error Unsupported architecture
 #endif


### PR DESCRIPTION
`riscv_EPC` value reference:
https://github.com/torvalds/linux/blob/a1375562c0a87f0fa2eaf3e8ce15824696d4170a/arch/riscv/include/asm/ptrace.h#L16