### PR TITLE
correct the license for debian folder

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -5,16 +5,16 @@ Source: <url://example.com>
 Files: *
 Copyright: <years> <put author's name and email here>
            <years> <likewise for another author>
-License: GPL-3.0+
+License: GPL-2.0+
 
 Files: debian/*
 Copyright: 2018 Paul Dreik <github@pauldreik.se>
-License: GPL-3.0+
+License: GPL-2.0+
 
-License: GPL-3.0+
+License: GPL-2.0+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
+ the Free Software Foundation, either version 2 of the License, or
  (at your option) any later version.
  .
  This package is distributed in the hope that it will be useful,
@@ -26,7 +26,7 @@ License: GPL-3.0+
  along with this program. If not, see <https://www.gnu.org/licenses/>.
  .
  On Debian systems, the complete text of the GNU General
- Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
 
 # Please also look if there are files or directories which have a
 # different copyright/license attached and list them here.


### PR DESCRIPTION
Assuming the license declared in debian folder should be the source of truth.

https://github.com/SimonKagstrom/kcov/blob/79a0e1f67a0c8a0c2c12ef2c5a9296ee9be2492c/debian/copyright#L5-L8

Then this PR is needed to correct the github license reporting (relates to https://github.com/Homebrew/homebrew-core/pull/119013)