### PR TITLE
Clear BFD disassembler state between ELF files

### DIFF
--- a/src/parsers/bfd-disassembler.cc
+++ b/src/parsers/bfd-disassembler.cc
@@ -90,6 +90,12 @@ public:
 
 	virtual void setup(const void *header, size_t headerSize)
 	{
+		// New ELF file, clear any state from the previous instance
+		m_cache.clear();
+		m_instructions.clear();
+		m_orderedInstructions.clear();
+		m_bbs.clear();
+
 		const uint8_t *data = (const uint8_t *)header;
 
 		panic_if(headerSize <= EI_CLASS,
@@ -377,7 +383,6 @@ private:
 		}
 	}
 
-
 	Instruction *getInstruction(uint64_t address)
 	{
 		if (m_instructions.find(address) == m_instructions.end())
@@ -385,8 +390,6 @@ private:
 
 		return &m_instructions[address];
 	}
-
-
 
 	void opcodesFprintFunc(const char *str)
 	{
@@ -436,7 +439,6 @@ private:
 
 	struct disassemble_info m_info;
 	disassembler_ftype m_disassembler;
-
 
 	std::vector<std::string> m_instructionVector;
 

--- a/src/parsers/bfd-disassembler.cc
+++ b/src/parsers/bfd-disassembler.cc
@@ -50,15 +50,11 @@ const std::set<std::string> x86BranchInstructions =
 		"jpo",
 		"js",
 		"jz",
-		"jczx"
-		"jezx"
-
+		"jczx",
+		"jezx",
 		"loop",
-
 		"jmp",
-
 		"call",
-
 		"ret",
 };
 


### PR DESCRIPTION
At a high-level, this makes the BFD disassembler forget all state from any previous ELF file that it's parsed when it's `setup` with a new one.  This prevents:

1. valid addresses from a previous ELF file being spuriously treated as valid in the new one (hopefully doesn't need any more detail)
2. (in)valid addresses from the new ELF file being "hidden" by section layouts from previous ELFs preventing the addresses from being checked at all (see below for an example)

This "forget all previous state" doesn't feel very user-friendly (it means the caller has to do everything it wants to with one ELF before moving on to the next one) but it's consistent with how the `elf-parser` code works.

## Background

I was hitting https://github.com/SimonKagstrom/kcov/issues/102 when covering some (very simple) rust code on Ubuntu Bionic.  The bad instruction was occurring in exactly the place mentioned in that issue, in `__pthread_enable_asynccancel` from `libpthread.so`, where the ASM source code looks like:

```
  54         lock
  55         cmpxchgl %r11d, %fs:CANCELHANDLING
  56         jnz     2b
```

Note that the `lock` prefix is on a separate line to the `cmpxchgl` (even though they're two parts of the same operation) and `gcc` and `clang` both helpfully insert separate debug info for those two lines, one pointing at the `lock` prefix opcode and the other pointing at the rest of the instruction.

The BFD disassembler can correctly see that the `cmpxchgl` is not a valid location to place an `int3` since it's not the start of an opcode, so normally this debug address is rejected as an invalid address (at least with `--verify`).  Despite this I was seeing the `cmpxchg` being replaced with `int3` leading to `SIG_ILL`s.

What was happening was that a previously inspected SO (possibly the original binary?) had included a section that started _after_ `libpthread`'s `.text` section, but ended _before_ the offset of the code related to `__pthread_enable_asynccancel`.  When the BFD parser was asked if the `cmpxchg` address was valid, it attempted to find the section that contained it, but the section searching code assumes (sensibly) that sections can't overlap, so it determined that the only section that _could_ contain the address was the one left over from the earlier ELF.  This section didn't extend far enough to cover the address so the BFD parser determined that the searched for address wasn't in a known section, and hence reported it as "valid" (for safety I guess?).  In another universe the address might have been found in a section but might have been marked as `valid` since a previous ELF had a valid instruction starting at that offset which would have led to the same end behaviour.

This seems to be incredibly hard to reproduce minimally (maybe by writing a custom linker script to lay out the sections manually?) and I imagine that the next release of libc/libpthread/rustc/ld/anything would have re-hidden the problem.  But better to fix it once and for all now that I've dug into it.

## Additional Changes

I also noticed and fixed up two other issues in the BFD parser code:

1. The list of branch instructions was missing some commas, which is annoyingly valid C/C++ code but meant the basic block detection code would ignore `jczx`, `jezx` and `loop` as branching instructions (instead looking for a `jczxjezxloop` opcode)
2. The section lookup code would fail if the address searched for was located in the section with the highest baseAddress (since `upper_bound` would return `end()` and the old code would bail out there)