### PR TITLE
Add basic support for LoongArch architecture

### DIFF
--- a/src/engines/ptrace.cc
+++ b/src/engines/ptrace.cc
@@ -52,6 +52,12 @@ static unsigned long arch_setupBreakpoint(unsigned long addr, unsigned long old_
 	val = (old_data & ~(0xffffffffUL << shift)) | (0xd4200000UL << shift);
 #elif defined(__riscv)
 	val = 0x00100073; /* ebreak */ // No width problem, prefer ebreak than c.ebreak for ISA w/o C extension.
+#elif defined(__loongarch__)
+	unsigned long aligned_addr = getAligned(addr);
+	unsigned long offs = addr - aligned_addr;
+	unsigned long shift = 8 * offs;
+
+	val = (old_data & ~(0xffffffffUL << shift)) | (0x002a0004UL << shift); /* break 0x4 */
 #else
 # error Unsupported architecture
 #endif

--- a/src/solib-parser/lib.c
+++ b/src/solib-parser/lib.c
@@ -97,6 +97,8 @@ static void force_breakpoint(void)
 			".long 0xd4200000\n" /* From https://github.com/scottt/debugbreak */
 #elif defined(__riscv)
 			"ebreak\n"
+#elif defined(__loongarch__)
+			"break 0x4\n"
 #else
 # error Unsupported architecture
 #endif


### PR DESCRIPTION
LoongArch documentation: https://loongson.github.io/LoongArch-Documentation/README-EN.html
ptrace reference: https://github.com/torvalds/linux/blob/82a2a51055895f419a3aaba15ffad419063191f0/arch/loongarch/include/uapi/asm/ptrace.h#L25)
breakpoint reference: https://github.com/torvalds/linux/blob/82a2a51055895f419a3aaba15ffad419063191f0/arch/loongarch/include/uapi/asm/break.h#L12