### PR TITLE
fix: mergeParser is registered twice

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -323,7 +323,6 @@ static int runKcov(IConfiguration::RunMode_t runningMode)
 		}
 	}
 
-	reporter.registerListener(mergeParser);
 	if (!conf.keyAsInt("cobertura-only"))
 	{
 		output.registerWriter(mergeParser);


### PR DESCRIPTION
Hi,
I'm reading your source code recently. It's beautiful work that providing a unified platform for binary instrumentation. But I found a bug, which may **significantly reduces the efficiency**.

The `mergeParser` will register itself to `reporter` while being initialized  in `merge-file-parser.cc:66`
```c++
	MergeParser(IReporter &reporter, const std::string &baseDirectory, const std::string &outputDirectory, IFilter &filter) :
			m_baseDirectory(baseDirectory), m_outputDirectory(outputDirectory), m_filter(filter)
	{
		reporter.registerListener(*this);
	}
```
However, it's registered manually in `main.cc`, which is deleted in this commit. This can be easily reproduced by adding `INFO_MSG` to `g_kcov_debug_mask` in `util.cc:27`, every **REPORT** line from the `mergeParser` will be duplicated, which means the `mergePaser`'s callback function `onLineReporter` is called twice.

This will cause redundant callback **when each line of source code is parsed by the parser**. According to my test report, this will add about 30% overhead on parsing stage.

Thank you for your reading. I'm looking forward to your further feedback.

(ps: Sorry for my English, I'm not a native speaker.)