### PR TITLE
configuration: refactorize code scanning for executables

### DIFF
--- a/src/include/utils.hh
+++ b/src/include/utils.hh
@@ -223,3 +223,7 @@ static inline uint32_t hash_block(const void *buf, size_t len)
 }
 
 uint32_t hash_file(const std::string &filename);
+
+// Searches for an executable named file in the directories named by the PATH
+// environment variable.
+int look_path(const std::string &file, std::string *out);


### PR DESCRIPTION
Add the `look_path` function for searching executable in directories named by the `PATH` environment variable in the `utils` source file.

Refactorize the `parse` function in configuration.cc, using the new `look_path` function.  This greatly simplify the code.

This PR implements an idea discussed #415.

The new change **should** behave the same as the current implementation, but unfortunately I can not verify this, because many tests fails on my system, probably due to incorrectly building the test suite.