### PR TITLE
configuration: fix incorrect handling of relative executables

### DIFF
--- a/src/include/utils.hh
+++ b/src/include/utils.hh
@@ -224,6 +224,12 @@ static inline uint32_t hash_block(const void *buf, size_t len)
 
 uint32_t hash_file(const std::string &filename);
 
+int find_executable(const std::string &file);
+
 // Searches for an executable named file in the directories named by the PATH
 // environment variable.
+// The named file is first tried directly without consulting PATH.
+//
+// Don't use this function when expanding the first argument of the exec()
+// family of functions, since it is insecure.
 int look_path(const std::string &file, std::string *out);


### PR DESCRIPTION
Commit 720eb98 (configuration: refactorize code scanning for executables) introduced a bug when the executable is a relative path. In this case the file is always expanded, thus causing file to be always considered non executable by the code scanning through the parameters in `configuration.cc`.

Update the `look_path` function to first try a file without consulting the `PATH` environment variable.

The old code worked because the last argument (before the executable arguments) was update correctly thanks to the loop over the `PATH` environment variable.

Note that the correct solution is to add "--" before the executable arguments, but this will break the `kcov` cli interface.

This change *should* restore the original behavior.
What's left is to actually fix #414.