### PR TITLE
ci.yml: update vmactions/freebsd to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
 
 
   build-freebsd:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     name: Build and test FreeBSD executable
     steps:
     - uses: actions/checkout@v3
     - name: FreeBSD
       id: test
-      uses: vmactions/freebsd-vm@v0
+      uses: vmactions/freebsd-vm@v1
       with:
         usesh: true
         sync: rsync


### PR DESCRIPTION
v1 is the most recommended to use and runs on ubuntu-latest instead of macos-12.