### PR TITLE
configuration: improve handling of positional arguments

### DIFF
--- a/tests/tools/basic.py
+++ b/tests/tools/basic.py
@@ -26,3 +26,11 @@ class LookupBinaryInPath(testbase.KcovTestCase):
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "second.py", 34) == 2
         assert noKcovRv, rv
+
+# Issue #414
+class OutDirectoryIsExecutable(testbase.KcovTestCase):
+    def runTest(self):
+        self.setUp()
+        rv,o = self.do(testbase.kcov + " echo python -V")
+
+        assert rv == 0


### PR DESCRIPTION
Currently `getopt_long` is configured to support mixing options and positional arguments, but `kcov` don't use the special "--" argument to tell `getopt_long` when to stop parsing the executable arguments. Instead the implementation tries to scan the arguments to find an executable, but the implementation is flawed because there are two required positional arguments, and both may be executable.

In order to handle positional arguments correctly, configure `getopt_long` to stop parsing after encountering a positional argument.

This change greatly simplified the code, since the pre scanning can be removed.  However it may break the workflow of some users.

Add a regression test for issue #414

## NOTES

The current implementation does not break the cli interface, but some user workflow may break.
In this case an alternative implementation is to configure `getopt_long` to report the positional arguments, too (using "-" instead of "+" as the `optstring` prefix).

Also note that the current configuration of `getopt` is the original UNIX behavior.

## ISSUES

This PR took longer than expected because I started to fix some issues with the test suite.

Additionally, after a system update (on Arch Linux) I started to see more failures.  These failures can be reproduced on the original implementation, commit 895f21d0.

Another issue is the regression test that I added.
The test fails with:
```console
rv: 255

stderr
Can't set me as ptraced: Operation not permitted
kcov: error: Can't start/attach to /usr/bin/python3.11
Child hasn't stopped: ff00
kcov: error: Can't start/attach to /usr/bin/python3.11
```

The command works correctly when running it maually, so I assume there is an issue in the test suite environment.

## P.S.

Issue #414 has been closed incorrectly.  This PR is responsible to close it.