### PR TITLE
configuration: improve getopt_long error reporting

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -171,6 +171,7 @@ public:
 		/* Hooray for reentrancy... */
 		optind = 0;
 		optarg = 0;
+		opterr = 0;
 		while (1)
 		{
 			int option_index = 0;
@@ -180,7 +181,7 @@ public:
 			// encountered.  This will ensure correct parsing of positional
 			// arguments without having to use "--" to stop parsing the
 			// executable arguments.
-			c = getopt_long(argc, (char **) argv, "+hp:s:l:t:", long_options,
+			c = getopt_long(argc, (char **) argv, "+:hp:s:l:t:", long_options,
 					&option_index);
 
 			/* No more options */
@@ -431,9 +432,16 @@ public:
 				}
 				break;
 			}
-			default:
-				error("Unrecognized option: -%c\n", optopt);
+			case ':':
+				error("Option %s requires an argument\n", argv[optind - 1]);
 				return usage();
+			case '?':
+			{
+				error("Unrecognized option: %s\n", argv[optind - 1]);
+				return usage();
+			}
+			default:
+				panic("unreachable");
 			}
 		}
 

--- a/tests/tools/basic.py
+++ b/tests/tools/basic.py
@@ -7,12 +7,16 @@ class TooFewArguments(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
         rv, output = self.do(testbase.kcov + " " + testbase.outbase + "/kcov")
+
+        assert b"Usage: kcov" in output
         assert rv == 1
 
 class WrongArguments(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
         rv, output = self.do(testbase.kcov + " --abc=efg " + testbase.outbase + "/kcov " + testbase.testbuild + "/tests-stripped")
+
+        assert b"kcov: error: Unrecognized option: --abc=efg" in output
         assert rv == 1
 
 class LookupBinaryInPath(testbase.KcovTestCase):


### PR DESCRIPTION
Currently, in case of an unrecognized option we get two error messages. The first is printed by `getopt_long` and the second is printed by `kcov` error handler.

An additional issue is that the `kcov` error handler prints `optopt`, but this value is `0` (NULL character) in this case.

Improve the error handler by using `optind` to get the offending option. This is done in a separate switch case, instead of the default case. Disable `getopt` error messages by setting `opterr` to 0.

Configure `getopt_long` to report a missing argument using a different error code, so that this can be handled in a separate switch case. Note however that this error is only reported when the option is the last argument.

Update the `basic.TooFewArguments` and `basic.WrongArguments` test cases.

## TODO

Print useful error message in case of an invalid option argument.  This PR will not implement it.