### PR TITLE
tests: fix basic.OutDirectoryIsExecutable

### DIFF
--- a/tests/python/short-test.py
+++ b/tests/python/short-test.py
@@ -1,9 +1,9 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 
 def doSomething():
-    print 'Hello world'
+    print('Hello world')
 
 
 if __name__ == '__main__':

--- a/tests/tools/basic.py
+++ b/tests/tools/basic.py
@@ -31,6 +31,10 @@ class LookupBinaryInPath(testbase.KcovTestCase):
 class OutDirectoryIsExecutable(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " echo python -V")
+        # Running a system executable on Linux may cause ptrace to fails with
+        # "Operation not permitted", even with ptrace_scope set to 0.
+        # See https://www.kernel.org/doc/Documentation/security/Yama.txt
+        executable = testbase.sources + "/tests/python/short-test.py"
+        rv,o = self.do(testbase.kcov + " echo " + executable)
 
         assert rv == 0


### PR DESCRIPTION
Commit 4b4cb9c (Merge pull request #426 from perillo/fix-argv-parsing) added a regression test, but the test failed due to `ptrace` errors on Linux.
The "Operation not permitted" error was caused by `kcov` trying to trace the "/bin/usr/python".

The solution is to execute an executable having user permission. Restore the `short-test.py` executable, and use it instead of `python`. `short-test.py` always exits with exit status 0.