### PR TITLE
tests: improve the test suite implementation

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+line-length = 100
+target-version = "py38" # default value
+
+[format]
+indent-style = "space" # default value
+
+[lint]
+# Enable Pyflakes (`F`), isort (`I`) and a subset of the pycodestyle (`E`) codes.
+select = ["E4", "E7", "E9", "F", "I"]
+
+[lint.pycodestyle]
+max-line-length = 100

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,8 @@ find_package (Threads REQUIRED)
 find_package (ZLIB REQUIRED)
 find_package (CURL REQUIRED)
 
+find_package (Python3 3.8 REQUIRED)
+
 if (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 set (DL_LIBRARY "")
 else (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)

--- a/tests/tools/accumulate.py
+++ b/tests/tools/accumulate.py
@@ -1,6 +1,6 @@
-import testbase
-import unittest
+
 import parse_cobertura
+import testbase
 
 
 class accumulate_data(testbase.KcovTestCase):

--- a/tests/tools/accumulate.py
+++ b/tests/tools/accumulate.py
@@ -2,79 +2,207 @@ import testbase
 import unittest
 import parse_cobertura
 
+
 class accumulate_data(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 16) == 1
         assert parse_cobertura.hitsPerLine(dom, "main", 19) == 0
         assert parse_cobertura.hitsPerLine(dom, "main", 14) == 1
 
-        rv,o = self.do(testbase.kcov + " "+ testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 16) == 1
         assert parse_cobertura.hitsPerLine(dom, "main", 19) == 1
         assert parse_cobertura.hitsPerLine(dom, "main", 14) == 2
 
+
 class dont_accumulate_data_with_clean(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 16) == 1
         assert parse_cobertura.hitsPerLine(dom, "main", 19) == 0
         assert parse_cobertura.hitsPerLine(dom, "main", 14) == 1
 
-        rv,o = self.do(testbase.kcov + " --clean "+ testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " --clean "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 16) == 0
         assert parse_cobertura.hitsPerLine(dom, "main", 19) == 1
         assert parse_cobertura.hitsPerLine(dom, "main", 14) == 1
 
+
 class merge_basic(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/kcov-merged/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 10) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 4) == 1
 
+
 class merge_multiple_output_directories(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov/first " + testbase.sources + "/tests/python/main 5")
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov/second " + testbase.sources + "/tests/bash/shell-main")
-        rv,o = self.do(testbase.kcov + " --merge " + testbase.outbase + "/kcov/merged " + testbase.outbase + "/kcov/first " + testbase.outbase + "/kcov/second")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov/first "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov/second "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
+        rv, o = self.do(
+            testbase.kcov
+            + " --merge "
+            + testbase.outbase
+            + "/kcov/merged "
+            + testbase.outbase
+            + "/kcov/first "
+            + testbase.outbase
+            + "/kcov/second"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/merged/kcov-merged/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 10) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 4) == 1
 
+
 class merge_merged_output(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov/first " + testbase.sources + "/tests/python/main 5")
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov/second " + testbase.sources + "/tests/bash/shell-main")
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov/third " + testbase.sources + "/tests/bash/dollar-var-replacements.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov/first "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov/second "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov/third "
+            + testbase.sources
+            + "/tests/bash/dollar-var-replacements.sh"
+        )
 
-        rv,o = self.do(testbase.kcov + " --merge " + testbase.outbase + "/kcov/merged " + testbase.outbase + "/kcov/first " + testbase.outbase + "/kcov/second")
-        rv,o = self.do(testbase.kcov + " --merge " + testbase.outbase + "/kcov/merged2 " + testbase.outbase + "/kcov/merged " + testbase.outbase + "/kcov/third")
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/merged2/kcov-merged/cobertura.xml")
+        rv, o = self.do(
+            testbase.kcov
+            + " --merge "
+            + testbase.outbase
+            + "/kcov/merged "
+            + testbase.outbase
+            + "/kcov/first "
+            + testbase.outbase
+            + "/kcov/second"
+        )
+        rv, o = self.do(
+            testbase.kcov
+            + " --merge "
+            + testbase.outbase
+            + "/kcov/merged2 "
+            + testbase.outbase
+            + "/kcov/merged "
+            + testbase.outbase
+            + "/kcov/third"
+        )
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/merged2/kcov-merged/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main", 10) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 4) == 1
         assert parse_cobertura.hitsPerLine(dom, "dollar-var-replacements.sh", 2) == 1
 
+
 class merge_coveralls(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --coveralls-id=dry-run " + testbase.outbase + "/kcov/ " + testbase.sources + "/tests/python/main 5")
-        rv,o = self.do(testbase.kcov + " --coveralls-id=dry-run " + testbase.outbase + "/kcov/ " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " --coveralls-id=dry-run "
+            + testbase.outbase
+            + "/kcov/ "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
+        rv, o = self.do(
+            testbase.kcov
+            + " --coveralls-id=dry-run "
+            + testbase.outbase
+            + "/kcov/ "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
 
-        rv,o = self.doShell("grep second.py %s/kcov/main/coveralls.out" % (testbase.outbase))
+        rv, o = self.doShell("grep second.py %s/kcov/main/coveralls.out" % (testbase.outbase))
         assert rv == 0
-        rv,o = self.doShell("grep shell-main %s/kcov/shell-main/coveralls.out" % (testbase.outbase))
+        rv, o = self.doShell(
+            "grep shell-main %s/kcov/shell-main/coveralls.out" % (testbase.outbase)
+        )
         assert rv == 0

--- a/tests/tools/bash.py
+++ b/tests/tools/bash.py
@@ -5,17 +5,34 @@ import platform
 import sys
 import parse_cobertura
 
+
 class BashBase(testbase.KcovTestCase):
     def doTest(self, args):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main " + args)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main "
+            + args
+        )
 
         return parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
+
 
 class bash_coverage(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 3) == None
@@ -40,20 +57,36 @@ class bash_coverage(testbase.KcovTestCase):
 class bash_coverage_debug_trap(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --bash-method=DEBUG " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-method=DEBUG "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 3) == None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 4) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 22) == 1
 
+
 class bash_short_file(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/short-test.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/short-test.sh"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/short-test.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "short-test.sh", 5) == 11
+
 
 class bash_heredoc_backslashes(BashBase):
     def runTest(self):
@@ -66,6 +99,7 @@ class bash_heredoc_backslashes(BashBase):
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 61) == None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 62) == None
 
+
 class bash_heredoc_special_cases_issue_44(BashBase):
     def runTest(self):
         dom = self.doTest("")
@@ -76,11 +110,13 @@ class bash_heredoc_special_cases_issue_44(BashBase):
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 109) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 118) == 1
 
+
 class bash_non_empty_braces(BashBase):
     def runTest(self):
         dom = self.doTest("")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 102) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 103) == 3
+
 
 class bash_coverage_tricky(BashBase):
     def runTest(self):
@@ -89,27 +125,54 @@ class bash_coverage_tricky(BashBase):
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 44) == None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 7) == None
 
+
 class bash_honor_signal(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.sources + "/tests/setpgid-kill/test-script.sh " + testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/trap.sh", False)
+        rv, o = self.do(
+            testbase.sources
+            + "/tests/setpgid-kill/test-script.sh "
+            + testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/trap.sh",
+            False,
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/trap.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "trap.sh", 5) == 1
 
+
 class bash_accumulate_data(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/unitundertest.sh 1")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/unitundertest.sh 1"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/unitundertest.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 6) == 1
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 16) == 0
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/unitundertest.sh 2")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/unitundertest.sh 2"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/unitundertest.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 6) == 1
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 16) == 1
+
 
 class bash_accumulate_changed_data(testbase.KcovTestCase):
     # Not sure why, but for now...
@@ -119,34 +182,60 @@ class bash_accumulate_changed_data(testbase.KcovTestCase):
         os.system("mkdir -p /tmp/test-kcov")
         os.system("cp " + testbase.sources + "/tests/bash/shell-main /tmp/test-kcov")
         os.system("cp " + testbase.sources + "/tests/bash/other.sh /tmp/test-kcov")
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov /tmp/test-kcov/shell-main 5 9")
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov /tmp/test-kcov/shell-main 5 9"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 40) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 67) == 2
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 6) == 2
         os.system("echo \"echo 'arne-anka'\" >> /tmp/test-kcov/shell-main")
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov /tmp/test-kcov/shell-main 5")
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov /tmp/test-kcov/shell-main 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 40) == 0
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 67) == 0
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 6) == 3
 
+
 class bash_merge_data_issue_38(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/unitundertest.sh 1")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/unitundertest.sh 1"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/unitundertest.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 6) == 1
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 16) == 0
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/unitundertest.sh 2")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/unitundertest.sh 2"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/unitundertest.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 6) == 1
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 16) == 1
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/unitundertest.sh all")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/unitundertest.sh all"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/unitundertest.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 36) == 1
@@ -154,10 +243,18 @@ class bash_merge_data_issue_38(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 33) == 1
         assert parse_cobertura.hitsPerLine(dom, "unitundertest.sh", 36) == 1
 
+
 class bash_issue_116_arithmetic_and_heredoc_issue_117_comment_within_string(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 142) == 1
@@ -165,99 +262,198 @@ class bash_issue_116_arithmetic_and_heredoc_issue_117_comment_within_string(test
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 151) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 152) == 1
 
+
 class bash_multiline_quotes(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/multiline-alias.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/multiline-alias.sh"
+        )
 
         assert b"echo called test_alias" not in o
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/multiline-alias.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "multiline-alias.sh", 6) == 1
 
+
 class bash_multiline_backslashes(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/multiline-backslash.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/multiline-backslash.sh"
+        )
 
         assert b"function_name" not in o
+
 
 class bash_no_executed_lines(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/no-executed-statements.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/no-executed-statements.sh"
+        )
 
         assert b"echo called test_alias" not in o
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/no-executed-statements.sh/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/no-executed-statements.sh/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "no-executed-statements.sh", 4) == 0
+
 
 class bash_stderr_redirection(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/redirect-stderr.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/redirect-stderr.sh"
+        )
 
         assert b"kcov" not in o
-        rv,o = self.do(testbase.kcov + " --debug-force-bash-stderr " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/redirect-stderr.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " --debug-force-bash-stderr "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/redirect-stderr.sh"
+        )
         assert b"kcov" not in o
+
 
 class bash_dollar_var_replacement(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/dollar-var-replacements.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/dollar-var-replacements.sh"
+        )
 
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/dollar-var-replacements.sh/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/dollar-var-replacements.sh/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "dollar-var-replacements.sh", 2) == 1
         assert parse_cobertura.hitsPerLine(dom, "dollar-var-replacements.sh", 4) == 1
         assert parse_cobertura.hitsPerLine(dom, "dollar-var-replacements.sh", 5) == 1
+
 
 # Issue #152
 class bash_done_eof(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main 5"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 163) == None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 169) == None
+
 
 # Issue #154
 class bash_eof_backtick(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 180) == 1
 
+
 class bash_subshell(testbase.KcovTestCase):
     def runTest(self):
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/subshell.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/subshell.sh"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/subshell.sh/cobertura.xml")
         self.assertIsNone(parse_cobertura.hitsPerLine(dom, "subshell.sh", 1))
         self.assertEqual(2, parse_cobertura.hitsPerLine(dom, "subshell.sh", 4))
         self.assertEqual(0, parse_cobertura.hitsPerLine(dom, "subshell.sh", 8))
 
+
 class bash_handle_all_output(testbase.KcovTestCase):
     def runTest(self):
         script = "handle-all-output.sh"
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " +
-            testbase.sources + "/tests/bash/" + script,
-            timeout=5.0)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/"
+            + script,
+            timeout=5.0,
+        )
         self.assertEqual(0, rv, "kcov exited unsuccessfully")
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/" + script + "/cobertura.xml")
         self.assertIsNone(parse_cobertura.hitsPerLine(dom, script, 1))
         self.assertEqual(1000, parse_cobertura.hitsPerLine(dom, script, 4))
 
+
 class bash_exit_status(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.sources + "/tests/bash/shell-main 5", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main 5")
+        noKcovRv, o = self.do(testbase.sources + "/tests/bash/shell-main 5", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main 5"
+        )
 
         assert rv == noKcovRv
+
 
 # Issue 180
 class bash_ignore_uncovered(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --exclude-region=CUSTOM_RANGE_START:CUSTOM_RANGE_END " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/other.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " --exclude-region=CUSTOM_RANGE_START:CUSTOM_RANGE_END "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/other.sh"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/other.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 22) == None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 23) == 1
@@ -286,31 +482,57 @@ class bash_ignore_uncovered(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 54) == None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 55) == 1
 
+
 # Issue #224
 class bash_can_find_non_executed_scripts(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/first-dir/a.sh 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/first-dir/a.sh 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/a.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "a.sh", 5) == 1
         # Not executed
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == 0
 
+
 class bash_can_find_non_executed_scripts_manually(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --bash-parse-files-in-dir=" + testbase.sources + "/tests/bash " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/first-dir/a.sh 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-parse-files-in-dir="
+            + testbase.sources
+            + "/tests/bash "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/first-dir/a.sh 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/a.sh/cobertura.xml")
         # Not executed
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == 0
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 3) == 0
 
+
 class bash_can_ignore_non_executed_scripts(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --bash-dont-parse-binary-dir " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/first-dir/a.sh 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-dont-parse-binary-dir "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/first-dir/a.sh 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/a.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "a.sh", 5) == 1
@@ -318,24 +540,45 @@ class bash_can_ignore_non_executed_scripts(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 3) == None
 
+
 class bash_can_ignore_function_with_spaces(testbase.KcovTestCase):
     def runTest(self):
-        rv,o = self.do(testbase.kcov + " --bash-dont-parse-binary-dir " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/function-with-spaces.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-dont-parse-binary-dir "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/function-with-spaces.sh"
+        )
 
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/function-with-spaces.sh/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/function-with-spaces.sh/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 5) == None
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 6) == 1
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 9) == None
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 10) == None
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 11) == 1
 
+
 class bash_drain_stdout_without_return(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " +
-            testbase.sources + "/tests/bash/long-output-without-return.sh",
-            timeout=5.0)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/long-output-without-return.sh",
+            timeout=5.0,
+        )
         self.assertEqual(0, rv, "kcov exited unsuccessfully")
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/long-output-without-return.sh/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/long-output-without-return.sh/cobertura.xml"
+        )
         self.assertIsNone(parse_cobertura.hitsPerLine(dom, "long-output-without-return.sh", 1))
-        self.assertEqual(32768, parse_cobertura.hitsPerLine(dom, "long-output-without-return.sh", 4))
+        self.assertEqual(
+            32768, parse_cobertura.hitsPerLine(dom, "long-output-without-return.sh", 4)
+        )

--- a/tests/tools/bash.py
+++ b/tests/tools/bash.py
@@ -1,9 +1,10 @@
-import testbase
 import os
-import unittest
 import platform
 import sys
+import unittest
+
 import parse_cobertura
+import testbase
 
 
 class BashBase(testbase.KcovTestCase):

--- a/tests/tools/bash.py
+++ b/tests/tools/bash.py
@@ -36,18 +36,18 @@ class bash_coverage(testbase.KcovTestCase):
         )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 3) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 3) is None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 4) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 13) == 0
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 26) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 26) is None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 30) == 5
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 34) == None
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 38) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 34) is None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 38) is None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 5) == 1
 
         assert parse_cobertura.hitsPerLine(dom, "short-test.sh", 5) == 11
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 128) == 1
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 132) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 132) is None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 135) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 136) == 1
 
@@ -68,7 +68,7 @@ class bash_coverage_debug_trap(testbase.KcovTestCase):
         )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 3) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 3) is None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 4) == 1
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 22) == 1
 
@@ -94,11 +94,11 @@ class bash_heredoc_backslashes(BashBase):
         dom = self.doTest("5")
 
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 52) == 4
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 53) == None
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 55) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 53) is None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 55) is None
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 59) == 1
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 61) == None
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 62) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 61) is None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 62) is None
 
 
 class bash_heredoc_special_cases_issue_44(BashBase):
@@ -122,9 +122,9 @@ class bash_non_empty_braces(BashBase):
 class bash_coverage_tricky(BashBase):
     def runTest(self):
         dom = self.doTest("5")
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 36) == None
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 44) == None
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 7) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 36) is None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 44) is None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 7) is None
 
 
 class bash_honor_signal(testbase.KcovTestCase):
@@ -372,8 +372,8 @@ class bash_done_eof(testbase.KcovTestCase):
             + "/tests/bash/shell-main 5"
         )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 163) == None
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 169) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 163) is None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 169) is None
 
 
 # Issue #154
@@ -456,31 +456,31 @@ class bash_ignore_uncovered(testbase.KcovTestCase):
             + "/tests/bash/other.sh"
         )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/other.sh/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 22) == None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 22) is None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 23) == 1
 
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 26) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 27) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 28) == None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 26) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 27) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 28) is None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 29) == 1
 
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 32) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 34) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 35) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 36) == None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 32) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 34) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 35) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 36) is None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 37) == 1
 
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 40) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 42) == None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 40) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 42) is None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 43) == 1
 
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 47) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 48) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 49) == None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 47) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 48) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 49) is None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 51) == 1
 
         # Rust stuff
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 54) == None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 54) is None
         assert parse_cobertura.hitsPerLine(dom, "other.sh", 55) == 1
 
 
@@ -538,8 +538,8 @@ class bash_can_ignore_non_executed_scripts(testbase.KcovTestCase):
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/a.sh/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "a.sh", 5) == 1
         # Not included in report
-        assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == None
-        assert parse_cobertura.hitsPerLine(dom, "other.sh", 3) == None
+        assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) is None
+        assert parse_cobertura.hitsPerLine(dom, "other.sh", 3) is None
 
 
 class bash_can_ignore_function_with_spaces(testbase.KcovTestCase):
@@ -556,10 +556,10 @@ class bash_can_ignore_function_with_spaces(testbase.KcovTestCase):
         dom = parse_cobertura.parseFile(
             testbase.outbase + "/kcov/function-with-spaces.sh/cobertura.xml"
         )
-        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 5) == None
+        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 5) is None
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 6) == 1
-        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 9) == None
-        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 10) == None
+        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 9) is None
+        assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 10) is None
         assert parse_cobertura.hitsPerLine(dom, "function-with-spaces.sh", 11) == 1
 
 

--- a/tests/tools/bash_linux_only.py
+++ b/tests/tools/bash_linux_only.py
@@ -1,7 +1,6 @@
-import testbase
-import os
-import unittest
+
 import parse_cobertura
+import testbase
 
 
 class bash_sh_shebang(testbase.KcovTestCase):

--- a/tests/tools/bash_linux_only.py
+++ b/tests/tools/bash_linux_only.py
@@ -3,32 +3,56 @@ import os
 import unittest
 import parse_cobertura
 
+
 class bash_sh_shebang(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --bash-handle-sh-invocation " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-handle-sh-invocation "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "sh-shebang.sh", 4) == 1
 
+
 class bash_exit_before_child(testbase.KcovTestCase):
     def runTest(self):
         # kcovKcov shouldn't wait for the background process, so call it with kcovKcov = False
-        rv,o = self.do(testbase.kcov + " --bash-tracefd-cloexec " + testbase.outbase + "/kcov " +
-            testbase.sources + "/tests/bash/background-child.sh",
-            kcovKcov = False,
-            timeout = 3.0,
-            kill = True)
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-tracefd-cloexec "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/background-child.sh",
+            kcovKcov=False,
+            timeout=3.0,
+            kill=True,
+        )
         self.assertEqual(0, rv, "kcov exited unsuccessfully")
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/background-child.sh/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/background-child.sh/cobertura.xml"
+        )
         self.assertIsNone(parse_cobertura.hitsPerLine(dom, "background-child.sh", 1))
         self.assertEqual(1, parse_cobertura.hitsPerLine(dom, "background-child.sh", 3))
         self.assertEqual(1, parse_cobertura.hitsPerLine(dom, "background-child.sh", 4))
 
+
 class bash_ldpreload_multilib(testbase.KcovTestCase):
     def runTest(self):
-        rv,o = self.do(testbase.kcov + " --bash-handle-sh-invocation --bash-tracefd-cloexec " + testbase.outbase + "/kcov " +
-            testbase.sources + "/tests/bash/sh-shebang.sh")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-handle-sh-invocation --bash-tracefd-cloexec "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/sh-shebang.sh"
+        )
         self.assertEqual(0, rv, "kcov exited unsuccessfully")
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/sh-shebang.sh/cobertura.xml")
         self.assertIsNone(parse_cobertura.hitsPerLine(dom, "sh-shebang.sh", 1))

--- a/tests/tools/basic.py
+++ b/tests/tools/basic.py
@@ -3,6 +3,7 @@ import unittest
 import parse_cobertura
 import os
 
+
 class TooFewArguments(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
@@ -11,25 +12,35 @@ class TooFewArguments(testbase.KcovTestCase):
         assert b"Usage: kcov" in output
         assert rv == 1
 
+
 class WrongArguments(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv, output = self.do(testbase.kcov + " --abc=efg " + testbase.outbase + "/kcov " + testbase.testbuild + "/tests-stripped")
+        rv, output = self.do(
+            testbase.kcov
+            + " --abc=efg "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/tests-stripped"
+        )
 
         assert b"kcov: error: Unrecognized option: --abc=efg" in output
         assert rv == 1
+
 
 class LookupBinaryInPath(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
         self.setUp()
         os.environ["PATH"] += testbase.sources + "/tests/python"
-        noKcovRv,o = self.do(testbase.sources + "/tests/python/main 5")
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + "main 5")
+        noKcovRv, o = self.do(testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + "main 5")
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "second.py", 34) == 2
         assert noKcovRv, rv
+
 
 # Issue #414
 class OutDirectoryIsExecutable(testbase.KcovTestCase):
@@ -39,6 +50,6 @@ class OutDirectoryIsExecutable(testbase.KcovTestCase):
         # "Operation not permitted", even with ptrace_scope set to 0.
         # See https://www.kernel.org/doc/Documentation/security/Yama.txt
         executable = testbase.sources + "/tests/python/short-test.py"
-        rv,o = self.do(testbase.kcov + " echo " + executable)
+        rv, o = self.do(testbase.kcov + " echo " + executable)
 
         assert rv == 0

--- a/tests/tools/basic.py
+++ b/tests/tools/basic.py
@@ -1,7 +1,8 @@
-import testbase
-import unittest
-import parse_cobertura
 import os
+import unittest
+
+import parse_cobertura
+import testbase
 
 
 class TooFewArguments(testbase.KcovTestCase):

--- a/tests/tools/compiled.py
+++ b/tests/tools/compiled.py
@@ -587,7 +587,7 @@ class debuglink(testbase.KcovTestCase):
         dom = parse_cobertura.parseFile(
             testbase.outbase + "/kcov/main-tests-debug-file/cobertura.xml"
         )
-        assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == None
+        assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) is None
 
 
 # Todo: Look in /usr/lib/debug as well

--- a/tests/tools/compiled.py
+++ b/tests/tools/compiled.py
@@ -1,9 +1,10 @@
-import testbase
-import unittest
-import parse_cobertura
-import sys
-import platform
 import os
+import platform
+import sys
+import unittest
+
+import parse_cobertura
+import testbase
 
 
 class illegal_insn(testbase.KcovTestCase):

--- a/tests/tools/compiled.py
+++ b/tests/tools/compiled.py
@@ -5,21 +5,39 @@ import sys
 import platform
 import os
 
+
 class illegal_insn(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     @unittest.skipUnless(platform.machine() in ["x86_64", "i686", "i386"], "Only for x86")
     def runTest(self):
         self.setUp()
-        rv, output = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/illegal-insn", False)
+        rv, output = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/illegal-insn",
+            False,
+        )
         assert rv != 0
-        assert b'Illegal instructions are' in output
+        assert b"Illegal instructions are" in output
+
 
 class fork_no_wait(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/fork_no_wait", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/fork_no_wait", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/fork_no_wait", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/fork_no_wait",
+            False,
+        )
         assert rv == noKcovRv
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/fork_no_wait/cobertura.xml")
@@ -27,11 +45,15 @@ class fork_no_wait(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "fork-no-wait.c", 22) >= 1
         assert parse_cobertura.hitsPerLine(dom, "fork-no-wait.c", 24) >= 1
 
+
 class ForkBase(testbase.KcovTestCase):
     def doTest(self, binary):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/" + binary, False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/" + binary, False)
+        noKcovRv, o = self.do(testbase.testbuild + "/" + binary, False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/" + binary,
+            False,
+        )
         assert rv == noKcovRv
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/" + binary + "/cobertura.xml")
@@ -41,10 +63,12 @@ class ForkBase(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "fork.c", 37) >= 1
         assert parse_cobertura.hitsPerLine(dom, "fork.c", 46) >= 1
 
+
 class fork_64(ForkBase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
         self.doTest("fork")
+
 
 class fork_32(ForkBase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
@@ -54,67 +78,94 @@ class fork_32(ForkBase):
         return
         self.doTest("fork-32")
 
+
 class vfork(testbase.KcovTestCase):
-    @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX (does not work with the mach-engine for now)")
+    @unittest.skipIf(
+        sys.platform.startswith("darwin"),
+        "Not for OSX (does not work with the mach-engine for now)",
+    )
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/vfork", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/vfork", False
+        )
         assert rv == 0
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/vfork/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "vfork.c", 12) >= 1
         assert parse_cobertura.hitsPerLine(dom, "vfork.c", 18) >= 1
 
+
 class popen_test(testbase.KcovTestCase):
     @unittest.skipUnless(platform.machine() in ["x86_64", "i686", "i386"], "Only for x86")
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/test_popen", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/test_popen", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/test_popen", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/test_popen",
+            False,
+        )
         assert rv == noKcovRv
 
         assert b"popen OK" in o
+
 
 class short_filename(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov ./s", False)
+        rv, o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov ./s", False)
         assert rv == 99
 
 
 class Pie(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/pie", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/pie", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie", False
+        )
         assert rv == noKcovRv
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/pie/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "pie.c", 5) == 1
 
+
 class pie_argv_basic(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie-test", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie-test",
+            False,
+        )
         assert rv == 0
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/pie-test/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "argv-dependent.c", 5) == 1
         assert parse_cobertura.hitsPerLine(dom, "argv-dependent.c", 11) == 0
+
 
 class pie_accumulate(testbase.KcovTestCase):
-    @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX (does not work with the mach-engine for now)")
+    @unittest.skipIf(
+        sys.platform.startswith("darwin"),
+        "Not for OSX (does not work with the mach-engine for now)",
+    )
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie-test", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie-test",
+            False,
+        )
         assert rv == 0
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/pie-test/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "argv-dependent.c", 5) == 1
         assert parse_cobertura.hitsPerLine(dom, "argv-dependent.c", 11) == 0
 
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie-test a", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie-test a",
+            False,
+        )
         assert rv == 0
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/pie-test/cobertura.xml")
@@ -125,33 +176,59 @@ class pie_accumulate(testbase.KcovTestCase):
 class global_ctors(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/global-constructors", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/global-constructors", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/global-constructors", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/global-constructors",
+            False,
+        )
         assert rv == noKcovRv
 
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/global-constructors/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/global-constructors/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "test-global-ctors.cc", 4) >= 1
+
 
 class daemon_wait_for_last_child(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #158")
     @unittest.skipUnless(platform.machine() in ["x86_64", "i686", "i386"], "Only for x86")
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/test_daemon", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/test_daemon", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/test_daemon", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/test_daemon",
+            False,
+        )
         assert rv == 4
         assert noKcovRv == 2
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/test_daemon/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "test-daemon.cc", 31) == 1
 
+
 class SignalsBase(testbase.KcovTestCase):
     def SignalsBase():
-        self.m_self = "";
+        self.m_self = ""
 
     def cmpOne(self, sig):
-        noKcovRv,o = self.do(testbase.testbuild + "/signals " + sig + " " + self.m_self, False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/signals " + sig + " " + self.m_self, False)
+        noKcovRv, o = self.do(testbase.testbuild + "/signals " + sig + " " + self.m_self, False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/signals "
+            + sig
+            + " "
+            + self.m_self,
+            False,
+        )
         assert rv == noKcovRv
 
         return parse_cobertura.parseFile(testbase.outbase + "/kcov/signals/cobertura.xml")
@@ -177,37 +254,62 @@ class SignalsBase(testbase.KcovTestCase):
         dom = self.cmpOne("term")
         assert parse_cobertura.hitsPerLine(dom, "test-signals.c", 84) == 1
 
+
 class signals(SignalsBase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #158")
-
     def runTest(self):
         self.m_self = ""
         self.doTest()
 
-class signals_self(SignalsBase):
 
+class signals_self(SignalsBase):
     def runTest(self):
         self.m_self = "self"
         self.doTest()
 
+
 class signals_crash(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX (macho-parser for now)")
-
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/signals segv self", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/signals segv self",
+            False,
+        )
         assert b"kcov: Process exited with signal 11" in o
 
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/signals abrt self", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/signals abrt self",
+            False,
+        )
         assert b"kcov: Process exited with signal 6" in o
+
 
 class collect_and_report_only(testbase.KcovTestCase):
     # Cannot work with combined Engine / Parser
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/main-tests ", False)
-        rv,o = self.do(testbase.kcov + " --collect-only " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/main-tests ", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " --collect-only "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests",
+            False,
+        )
         print("Fickle test, ignoring")
         return
         assert rv == noKcovRv
@@ -219,23 +321,59 @@ class collect_and_report_only(testbase.KcovTestCase):
             # Exception is expected here
             pass
 
-        rv,o = self.do(testbase.kcov + " --report-only " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " --report-only "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests",
+            False,
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
+
 
 class setpgid_kill(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.sources + "/tests/setpgid-kill/test-script.sh " + testbase.testbuild + "/setpgid-kill", False)
+        noKcovRv, o = self.do(
+            testbase.sources
+            + "/tests/setpgid-kill/test-script.sh "
+            + testbase.testbuild
+            + "/setpgid-kill",
+            False,
+        )
         assert b"SUCCESS" in o
-        rv,o = self.do(testbase.sources + "/tests/setpgid-kill/test-script.sh " + testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/setpgid-kill", False)
+        rv, o = self.do(
+            testbase.sources
+            + "/tests/setpgid-kill/test-script.sh "
+            + testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/setpgid-kill",
+            False,
+        )
         assert b"SUCCESS" in o
+
 
 class attach_process_with_threads(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.sources + "/tests/daemon/test-script.sh " + testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/issue31", False)
+        rv, o = self.do(
+            testbase.sources
+            + "/tests/daemon/test-script.sh "
+            + testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/issue31",
+            False,
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/issue31/cobertura.xml")
         print("Fickle test, ignoring")
         return
@@ -243,32 +381,53 @@ class attach_process_with_threads(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "test-issue31.cc", 11) >= 1
         assert parse_cobertura.hitsPerLine(dom, "test-issue31.cc", 9) == 0
 
+
 class attach_process_with_threads_creates_threads(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.sources + "/tests/daemon/test-script.sh " + testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/thread-test", False)
+        rv, o = self.do(
+            testbase.sources
+            + "/tests/daemon/test-script.sh "
+            + testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/thread-test",
+            False,
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/thread-test/cobertura.xml")
         print("Fickle test, ignoring")
         return
         assert parse_cobertura.hitsPerLine(dom, "thread-main.c", 21) >= 1
         assert parse_cobertura.hitsPerLine(dom, "thread-main.c", 9) >= 1
 
+
 class merge_same_file_in_multiple_binaries(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/multi_1", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/multi_1",
+            False,
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/multi_1/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main_1.c", 10) == 0
         assert parse_cobertura.hitsPerLine(dom, "file.c", 3) == 0
 
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/multi_2", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/multi_2",
+            False,
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/kcov-merged/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main_2.c", 9) == 1
         assert parse_cobertura.hitsPerLine(dom, "file.c", 3) == 0
         assert parse_cobertura.hitsPerLine(dom, "file.c", 8) == 0
 
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/multi_2 1", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/multi_2 1",
+            False,
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/kcov-merged/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "file.c", 3) == 0
         assert parse_cobertura.hitsPerLine(dom, "file.c", 8) == 1
@@ -279,59 +438,159 @@ class debuglink(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
         os.system("rm -rf %s/.debug" % (testbase.outbase))
-        os.system("cp %s/main-tests %s/main-tests-debug-file" % (testbase.testbuild, testbase.testbuild))
-        os.system("objcopy --only-keep-debug %s/main-tests-debug-file %s/main-tests-debug-file.debug" % (testbase.testbuild, testbase.testbuild))
-        os.system("cp %s/main-tests-debug-file.debug %s/main-tests-debug-file1.debug" % (testbase.testbuild, testbase.testbuild))
-        os.system("cp %s/main-tests-debug-file.debug %s/main-tests-debug-file12.debug" % (testbase.testbuild, testbase.testbuild))
-        os.system("cp %s/main-tests-debug-file.debug %s/main-tests-debug-file123.debug" % (testbase.testbuild, testbase.testbuild))
-        os.system("cp %s/main-tests-debug-file %s/main-tests-debug-file1" % (testbase.testbuild, testbase.testbuild))
-        os.system("cp %s/main-tests-debug-file %s/main-tests-debug-file2" % (testbase.testbuild, testbase.testbuild))
-        os.system("cp %s/main-tests-debug-file %s/main-tests-debug-file3" % (testbase.testbuild, testbase.testbuild))
+        os.system(
+            "cp %s/main-tests %s/main-tests-debug-file" % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "objcopy --only-keep-debug %s/main-tests-debug-file %s/main-tests-debug-file.debug"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "cp %s/main-tests-debug-file.debug %s/main-tests-debug-file1.debug"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "cp %s/main-tests-debug-file.debug %s/main-tests-debug-file12.debug"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "cp %s/main-tests-debug-file.debug %s/main-tests-debug-file123.debug"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "cp %s/main-tests-debug-file %s/main-tests-debug-file1"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "cp %s/main-tests-debug-file %s/main-tests-debug-file2"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "cp %s/main-tests-debug-file %s/main-tests-debug-file3"
+            % (testbase.testbuild, testbase.testbuild)
+        )
         os.system("strip -g %s/main-tests-debug-file" % (testbase.testbuild))
         os.system("strip -g %s/main-tests-debug-file1" % (testbase.testbuild))
         os.system("strip -g %s/main-tests-debug-file2" % (testbase.testbuild))
         os.system("strip -g %s/main-tests-debug-file3" % (testbase.testbuild))
-        os.system("objcopy --add-gnu-debuglink=%s/main-tests-debug-file.debug %s/main-tests-debug-file" % (testbase.testbuild, testbase.testbuild))
-        os.system("objcopy --add-gnu-debuglink=%s/main-tests-debug-file1.debug %s/main-tests-debug-file1" % (testbase.testbuild, testbase.testbuild))
-        os.system("objcopy --add-gnu-debuglink=%s/main-tests-debug-file12.debug %s/main-tests-debug-file2" % (testbase.testbuild, testbase.testbuild))
-        os.system("objcopy --add-gnu-debuglink=%s/main-tests-debug-file123.debug %s/main-tests-debug-file3" % (testbase.testbuild, testbase.testbuild))
+        os.system(
+            "objcopy --add-gnu-debuglink=%s/main-tests-debug-file.debug %s/main-tests-debug-file"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "objcopy --add-gnu-debuglink=%s/main-tests-debug-file1.debug %s/main-tests-debug-file1"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "objcopy --add-gnu-debuglink=%s/main-tests-debug-file12.debug %s/main-tests-debug-file2"
+            % (testbase.testbuild, testbase.testbuild)
+        )
+        os.system(
+            "objcopy --add-gnu-debuglink=%s/main-tests-debug-file123.debug %s/main-tests-debug-file3"
+            % (testbase.testbuild, testbase.testbuild)
+        )
 
-        noKcovRv,o = self.do(testbase.testbuild + "/main-tests-debug-file", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests-debug-file", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/main-tests-debug-file", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests-debug-file",
+            False,
+        )
         assert rv == noKcovRv
 
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests-debug-file/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/main-tests-debug-file/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
 
         # Check alignment
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests-debug-file1", False)
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests-debug-file1/cobertura.xml")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests-debug-file1",
+            False,
+        )
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/main-tests-debug-file1/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
 
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests-debug-file2", False)
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests-debug-file2/cobertura.xml")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests-debug-file2",
+            False,
+        )
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/main-tests-debug-file2/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
 
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests-debug-file3", False)
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests-debug-file3/cobertura.xml")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests-debug-file3",
+            False,
+        )
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/main-tests-debug-file3/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
 
         # Look in .debug
         os.system("rm -rf %s/kcov" % (testbase.outbase))
         os.system("mkdir -p %s/.debug" % (testbase.testbuild))
-        os.system("mv %s/main-tests-debug-file.debug %s/.debug" % (testbase.testbuild, testbase.testbuild))
+        os.system(
+            "mv %s/main-tests-debug-file.debug %s/.debug" % (testbase.testbuild, testbase.testbuild)
+        )
 
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests-debug-file", False)
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests-debug-file/cobertura.xml")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests-debug-file",
+            False,
+        )
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/main-tests-debug-file/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
 
         os.system("rm -rf %s/kcov" % (testbase.outbase))
         os.system("echo 'abc' >> %s/.debug/main-tests-debug-file.debug" % (testbase.testbuild))
 
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests-debug-file", False)
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests-debug-file/cobertura.xml")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests-debug-file",
+            False,
+        )
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/main-tests-debug-file/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == None
-	# Todo: Look in /usr/lib/debug as well
+
+
+# Todo: Look in /usr/lib/debug as well
+
 
 class collect_no_source(testbase.KcovTestCase):
     @unittest.expectedFailure
@@ -339,23 +598,44 @@ class collect_no_source(testbase.KcovTestCase):
         self.setUp()
 
         os.system("cp %s/tests/short-file.c %s/main.cc" % (testbase.sources, testbase.testbuild))
-        os.system("gcc -g -o %s/main-collect-only %s/main.cc" % (testbase.testbuild, testbase.testbuild))
+        os.system(
+            "gcc -g -o %s/main-collect-only %s/main.cc" % (testbase.testbuild, testbase.testbuild)
+        )
         os.system("mv %s/main.cc %s/tmp-main.cc" % (testbase.testbuild, testbase.testbuild))
 
-        rv,o = self.do(testbase.kcov + " --collect-only " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-collect-only", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " --collect-only "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-collect-only",
+            False,
+        )
 
         os.system("mv %s/tmp-main.cc %s/main.cc" % (testbase.testbuild, testbase.testbuild))
-        rv,o = self.do(testbase.kcov + " --report-only " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-collect-only")
+        rv, o = self.do(
+            testbase.kcov
+            + " --report-only "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-collect-only"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-collect-only/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 1) == 1
+
 
 class dlopen(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/dlopen", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/dlopen", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/dlopen", False)
+        rv, o = self.do(
+            testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/dlopen",
+            False,
+        )
 
         assert noKcovRv == rv
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/dlopen/cobertura.xml")
@@ -369,19 +649,36 @@ class dlopen_in_ignored_source_file(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --exclude-pattern=dlopen.cc " + testbase.outbase + "/kcov " + testbase.testbuild + "/dlopen", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " --exclude-pattern=dlopen.cc "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/dlopen",
+            False,
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/dlopen/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "dlopen-main.cc", 10) == 1
         assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) == 1
         assert parse_cobertura.hitsPerLine(dom, "solib.c", 12) == 0
+
 
 class daemon_no_wait_for_last_child(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     @unittest.expectedFailure
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/test_daemon", False)
-        rv,o = self.do(testbase.kcov + " --output-interval=1 --exit-first-process " + testbase.outbase + "/kcov " + testbase.testbuild + "/test_daemon", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/test_daemon", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " --output-interval=1 --exit-first-process "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/test_daemon",
+            False,
+        )
 
         assert noKcovRv == rv
         time.sleep(2)
@@ -398,10 +695,18 @@ class address_sanitizer_coverage(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
         self.setUp()
-        if (not os.path.isfile(testbase.testbuild + "/sanitizer-coverage")):
+        if not os.path.isfile(testbase.testbuild + "/sanitizer-coverage"):
             print("Clang-only")
             assert False
-        rv,o = self.do(testbase.kcov + " --clang " + testbase.outbase + "/kcov " + testbase.testbuild + "/sanitizer-coverage", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " --clang "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/sanitizer-coverage",
+            False,
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/sanitizer-coverage/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "sanitizer-coverage.c", 5) == 1

--- a/tests/tools/compiled_basic.py
+++ b/tests/tools/compiled_basic.py
@@ -52,7 +52,7 @@ class shared_library_skip(testbase.KcovTestCase):
             testbase.outbase + "/kcov/shared_library_test/cobertura.xml"
         )
         assert parse_cobertura.hitsPerLine(dom, "main.c", 9) == 1
-        assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) == None
+        assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) is None
 
 
 class shared_library_filter_out(testbase.KcovTestCase):
@@ -74,7 +74,7 @@ class shared_library_filter_out(testbase.KcovTestCase):
             testbase.outbase + "/kcov/shared_library_test/cobertura.xml"
         )
         assert parse_cobertura.hitsPerLine(dom, "main.c", 9) == 1
-        assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) == None
+        assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) is None
 
 
 class shared_library_accumulate(testbase.KcovTestCase):
@@ -120,7 +120,7 @@ class MainTestBase(testbase.KcovTestCase):
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
-        assert parse_cobertura.hitsPerLine(dom, "main.cc", 14) == None
+        assert parse_cobertura.hitsPerLine(dom, "main.cc", 14) is None
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 18) >= 1
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 25) == 1
         assert parse_cobertura.hitsPerLine(dom, "file.c", 6) >= 1

--- a/tests/tools/compiled_basic.py
+++ b/tests/tools/compiled_basic.py
@@ -1,9 +1,8 @@
-import testbase
-import unittest
-import parse_cobertura
 import sys
-import platform
-import os
+import unittest
+
+import parse_cobertura
+import testbase
 
 
 class shared_library(testbase.KcovTestCase):

--- a/tests/tools/compiled_basic.py
+++ b/tests/tools/compiled_basic.py
@@ -7,27 +7,51 @@ import os
 
 
 class shared_library(testbase.KcovTestCase):
-    @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX (does not work with the mach-engine for now)")
+    @unittest.skipIf(
+        sys.platform.startswith("darwin"),
+        "Not for OSX (does not work with the mach-engine for now)",
+    )
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.testbuild + "/shared_library_test", False)
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/shared_library_test", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/shared_library_test", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/shared_library_test",
+            False,
+        )
         assert rv == noKcovRv
 
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shared_library_test/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/shared_library_test/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.c", 9) >= 1
         assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) == 1
+
 
 class shared_library_skip(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #157")
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --skip-solibs " + testbase.outbase + "/kcov " + testbase.testbuild + "/shared_library_test", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " --skip-solibs "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/shared_library_test",
+            False,
+        )
         print("Fickle test, ignoring")
         return
         assert rv == 0
 
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shared_library_test/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/shared_library_test/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.c", 9) == 1
         assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) == None
 
@@ -36,10 +60,20 @@ class shared_library_filter_out(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #157")
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --exclude-pattern=solib " + testbase.outbase + "/kcov " + testbase.testbuild + "/shared_library_test", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " --exclude-pattern=solib "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/shared_library_test",
+            False,
+        )
         assert rv == 0
 
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shared_library_test/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/shared_library_test/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.c", 9) == 1
         assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) == None
 
@@ -48,20 +82,41 @@ class shared_library_accumulate(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #157")
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/shared_library_test 5", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/shared_library_test 5",
+            False,
+        )
         assert rv == 0
 
-        dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shared_library_test/cobertura.xml")
+        dom = parse_cobertura.parseFile(
+            testbase.outbase + "/kcov/shared_library_test/cobertura.xml"
+        )
         assert parse_cobertura.hitsPerLine(dom, "main.c", 9) == 1
         assert parse_cobertura.hitsPerLine(dom, "solib.c", 5) == 1
         assert parse_cobertura.hitsPerLine(dom, "solib.c", 10) == 1
+
 
 class MainTestBase(testbase.KcovTestCase):
     def doTest(self, verify):
         self.setUp()
 
-        noKcovRv,o = self.do(testbase.testbuild + "/main-tests", False)
-        rv,o = self.do(testbase.kcov + " " + verify + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/main-tests 5", False)
+        noKcovRv, o = self.do(testbase.testbuild + "/main-tests", False)
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + verify
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/main-tests 5",
+            False,
+        )
         assert rv == noKcovRv
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main-tests/cobertura.xml")
@@ -77,9 +132,11 @@ class main_test(MainTestBase):
     def runTest(self):
         self.doTest("")
 
+
 class main_test_verify(MainTestBase):
     def runTest(self):
         self.doTest("--verify")
+
 
 class main_test_lldb_raw_breakpoints(MainTestBase):
     def runTest(self):

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -2,21 +2,43 @@ import testbase
 import unittest
 import parse_cobertura
 
+
 class include_exclude_pattern(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --bash-dont-parse-binary-dir --exclude-pattern=first-dir " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-dont-parse-binary-dir --exclude-pattern=first-dir "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) >= 1
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == None
 
-        rv,o = self.do(testbase.kcov + " --include-pattern=first-dir " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " --include-pattern=first-dir "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) == None
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) >= 1
 
-        rv,o = self.do(testbase.kcov + " --include-pattern=first-dir --exclude-pattern=c.sh " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " --include-pattern=first-dir --exclude-pattern=c.sh "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) == None
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == None
@@ -26,17 +48,36 @@ class include_exclude_pattern(testbase.KcovTestCase):
 class include_path(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --bash-dont-parse-binary-dir --include-path=" + testbase.sources + "/tests/bash/first-dir " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-dont-parse-binary-dir --include-path="
+            + testbase.sources
+            + "/tests/bash/first-dir "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) == None
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) >= 1
         assert parse_cobertura.hitsPerLine(dom, "b.sh", 3) >= 1
 
+
 class include_path_and_exclude_pattern(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --bash-dont-parse-binary-dir --include-path=" + testbase.sources + "/tests/bash/first-dir --exclude-pattern=b.sh " + testbase.outbase + "/kcov " + testbase.sources + "/tests/bash/shell-main")
+        rv, o = self.do(
+            testbase.kcov
+            + " --bash-dont-parse-binary-dir --include-path="
+            + testbase.sources
+            + "/tests/bash/first-dir --exclude-pattern=b.sh "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/bash/shell-main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) == None

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -1,6 +1,6 @@
-import testbase
-import unittest
+
 import parse_cobertura
+import testbase
 
 
 class include_exclude_pattern(testbase.KcovTestCase):

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -17,7 +17,7 @@ class include_exclude_pattern(testbase.KcovTestCase):
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) >= 1
-        assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == None
+        assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) is None
 
         rv, o = self.do(
             testbase.kcov
@@ -28,7 +28,7 @@ class include_exclude_pattern(testbase.KcovTestCase):
             + "/tests/bash/shell-main"
         )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) is None
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) >= 1
 
         rv, o = self.do(
@@ -40,8 +40,8 @@ class include_exclude_pattern(testbase.KcovTestCase):
             + "/tests/bash/shell-main"
         )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) == None
-        assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) is None
+        assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) is None
         assert parse_cobertura.hitsPerLine(dom, "b.sh", 3) >= 1
 
 
@@ -60,7 +60,7 @@ class include_path(testbase.KcovTestCase):
         )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) is None
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) >= 1
         assert parse_cobertura.hitsPerLine(dom, "b.sh", 3) >= 1
 
@@ -80,6 +80,6 @@ class include_path_and_exclude_pattern(testbase.KcovTestCase):
         )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/shell-main/cobertura.xml")
-        assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) == None
+        assert parse_cobertura.hitsPerLine(dom, "shell-main", 29) is None
         assert parse_cobertura.hitsPerLine(dom, "c.sh", 3) >= 1
-        assert parse_cobertura.hitsPerLine(dom, "b.sh", 3) == None
+        assert parse_cobertura.hitsPerLine(dom, "b.sh", 3) is None

--- a/tests/tools/parse_cobertura.py
+++ b/tests/tools/parse_cobertura.py
@@ -55,9 +55,9 @@ def hitsPerLine(dom, fileName, lineNr):
     fileName = fileName.replace(".", "_").replace("-", "_")
     fileTag = lookupClassName(dom, fileName)
 
-    if fileTag != None:
+    if fileTag is not None:
         hits = lookupHitsByLine(fileTag, lineNr)
-        if hits != None:
+        if hits is not None:
             return hits
 
     return None
@@ -76,9 +76,9 @@ if __name__ == "__main__":
     dom = parse(data)
     fileTag = lookupClassName(dom, fileName)
 
-    if fileTag != None:
+    if fileTag is not None:
         hits = lookupHitsByLine(fileTag, line)
-        if hits != None:
+        if hits is not None:
             print(hits)
             sys.exit(0)
 

--- a/tests/tools/parse_cobertura.py
+++ b/tests/tools/parse_cobertura.py
@@ -3,10 +3,11 @@
 import sys
 import xml.dom.minidom
 
-#all these imports are standard on most modern python implementations
+# all these imports are standard on most modern python implementations
+
 
 def readFile(name):
-    f = open(name,'r')
+    f = open(name, "r")
     data = f.read()
     f.close()
 
@@ -14,7 +15,7 @@ def readFile(name):
 
 
 def lookupClassName(dom, name):
-    tags = dom.getElementsByTagName('class')
+    tags = dom.getElementsByTagName("class")
 
     for tag in tags:
         nameAttr = tag.attributes["name"]
@@ -23,8 +24,9 @@ def lookupClassName(dom, name):
 
     return None
 
+
 def lookupHitsByLine(classTag, lineNr):
-    tags = classTag.getElementsByTagName('line')
+    tags = classTag.getElementsByTagName("line")
 
     for tag in tags:
         numberAttr = tag.attributes["number"]
@@ -36,19 +38,20 @@ def lookupHitsByLine(classTag, lineNr):
 
 
 def parse(data):
-    #parse the xml you got from the file
+    # parse the xml you got from the file
     dom = xml.dom.minidom.parseString(data)
 
     return dom
 
+
 def parseFile(filename):
-    #parse the xml you got from the file
+    # parse the xml you got from the file
     dom = xml.dom.minidom.parseString(readFile(filename))
 
     return dom
 
-def hitsPerLine(dom, fileName, lineNr):
 
+def hitsPerLine(dom, fileName, lineNr):
     fileName = fileName.replace(".", "_").replace("-", "_")
     fileTag = lookupClassName(dom, fileName)
 
@@ -59,11 +62,11 @@ def hitsPerLine(dom, fileName, lineNr):
 
     return None
 
+
 if __name__ == "__main__":
     if len(sys.argv) < 4:
         print("Usage: lookup-class-line <in-file> <filename> <lineNr>")
         sys.exit(1)
-
 
     fileName = sys.argv[2]
     line = int(sys.argv[3])

--- a/tests/tools/python.py
+++ b/tests/tools/python.py
@@ -2,54 +2,112 @@ import testbase
 import unittest
 import parse_cobertura
 
+
 class python_exit_status(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        noKcovRv,o = self.do(testbase.sources + "/tests/python/main 5")
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        noKcovRv, o = self.do(testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         assert rv == noKcovRv
+
 
 class python_can_set_illegal_parser(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --python-parser=python7 " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " --python-parser=python7 "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         assert b"Cannot find Python parser 'python7'" in o
+
 
 class python_can_set_legal_parser(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --python-parser=python3 " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " --python-parser=python3 "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         assert b"Cannot find Python parser 'python3'" not in o
+
 
 class python2_can_set_legal_parser(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --python-parser=python2 " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " --python-parser=python2 "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         assert b"Cannot find Python parser 'python2'" not in o
+
 
 class python_issue_368_can_handle_symlink_target(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --python-parser=python3 " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/link_main 5 --foo")
+        rv, o = self.do(
+            testbase.kcov
+            + " --python-parser=python3 "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/link_main 5 --foo"
+        )
 
         assert b"unrecognized option '--foo'" not in o
+
 
 class python_unittest(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/unittest/testdriver")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/unittest/testdriver"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/testdriver/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "testdriver", 14) == 1
 
+
 class PythonBase(testbase.KcovTestCase):
     def doTest(self, extra):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + extra + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + extra
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 10) == 2
@@ -68,19 +126,35 @@ class PythonBase(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "second.py", 65) == None
         assert parse_cobertura.hitsPerLine(dom, "second.py", 77) == None
 
+
 class python_coverage(PythonBase):
     def runTestTest(self):
         self.doTest("")
 
+
 class python_accumulate_data(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 16) == 0
         assert parse_cobertura.hitsPerLine(dom, "main", 19) == 1
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 16) == 1
@@ -91,30 +165,57 @@ class python3_coverage(PythonBase):
     def runTest(self):
         self.doTest("--python-parser=python3")
 
+
 class python2_coverage(PythonBase):
     def runTest(self):
         self.doTest("--python-parser=python2")
 
+
 class python_tricky_single_line_string_assignment(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "second.py", 34) == 2
 
+
 class python_select_parser(testbase.KcovTestCase):
     def disabledTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --python-parser=" + testbase.sources + "/tests/tools/dummy-python.sh " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " --python-parser="
+            + testbase.sources
+            + "/tests/tools/dummy-python.sh "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         assert rv == 99
+
 
 class python_tricky_single_dict_assignment(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.sources + "/tests/python/main 5")
+        rv, o = self.do(
+            testbase.kcov
+            + " "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.sources
+            + "/tests/python/main 5"
+        )
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "second.py", 57) == 1

--- a/tests/tools/python.py
+++ b/tests/tools/python.py
@@ -1,6 +1,7 @@
-import testbase
 import unittest
+
 import parse_cobertura
+import testbase
 
 
 class python_exit_status(testbase.KcovTestCase):

--- a/tests/tools/python.py
+++ b/tests/tools/python.py
@@ -113,19 +113,19 @@ class PythonBase(testbase.KcovTestCase):
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/main/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main", 10) == 2
         assert parse_cobertura.hitsPerLine(dom, "main", 17) == 0
-        assert parse_cobertura.hitsPerLine(dom, "main", 22) == None
+        assert parse_cobertura.hitsPerLine(dom, "main", 22) is None
         assert parse_cobertura.hitsPerLine(dom, "second.py", 2) == 1
-        assert parse_cobertura.hitsPerLine(dom, "second.py", 4) == None
-        assert parse_cobertura.hitsPerLine(dom, "second.py", 11) == None
+        assert parse_cobertura.hitsPerLine(dom, "second.py", 4) is None
+        assert parse_cobertura.hitsPerLine(dom, "second.py", 11) is None
         assert parse_cobertura.hitsPerLine(dom, "second.py", 31) == 0
         assert parse_cobertura.hitsPerLine(dom, "second.py", 38) == 1
         assert parse_cobertura.hitsPerLine(dom, "second.py", 39) == 0
-        assert parse_cobertura.hitsPerLine(dom, "second.py", 40) == None
+        assert parse_cobertura.hitsPerLine(dom, "second.py", 40) is None
         assert parse_cobertura.hitsPerLine(dom, "second.py", 41) == 1
-        assert parse_cobertura.hitsPerLine(dom, "second.py", 56) == None
-        assert parse_cobertura.hitsPerLine(dom, "second.py", 60) == None
-        assert parse_cobertura.hitsPerLine(dom, "second.py", 65) == None
-        assert parse_cobertura.hitsPerLine(dom, "second.py", 77) == None
+        assert parse_cobertura.hitsPerLine(dom, "second.py", 56) is None
+        assert parse_cobertura.hitsPerLine(dom, "second.py", 60) is None
+        assert parse_cobertura.hitsPerLine(dom, "second.py", 65) is None
+        assert parse_cobertura.hitsPerLine(dom, "second.py", 77) is None
 
 
 class python_coverage(PythonBase):

--- a/tests/tools/run-tests
+++ b/tests/tools/run-tests
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
+import platform
 import sys
 import unittest
+
 import testbase
-import platform
 
 # The actual tests
 from basic import *
@@ -16,10 +17,10 @@ if sys.platform.startswith("linux"):
 
     if platform.machine() in ["x86_64", "i386", "i686"]:
         from system_mode import *
-from filter import *
 from accumulate import *
-from python import *
 from bash import *
+from filter import *
+from python import *
 
 if __name__ == "__main__":
     if len(sys.argv) < 5:

--- a/tests/tools/run-tests
+++ b/tests/tools/run-tests
@@ -8,10 +8,12 @@ import platform
 # The actual tests
 from basic import *
 from compiled_basic import *
+
 if platform.machine() in ["x86_64", "i386", "i686"]:
     from compiled import *
 if sys.platform.startswith("linux"):
     from bash_linux_only import *
+
     if platform.machine() in ["x86_64", "i386", "i686"]:
         from system_mode import *
 from filter import *
@@ -21,7 +23,9 @@ from bash import *
 
 if __name__ == "__main__":
     if len(sys.argv) < 5:
-        print("Usage: run-tests <path-to-kcov-binary> <kcov-output> <path-to-test-builds> <path-to-kcov-source>")
+        print(
+            "Usage: run-tests <path-to-kcov-binary> <kcov-output> <path-to-test-builds> <path-to-kcov-source>"
+        )
         sys.exit(1)
 
     testbase.configure(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/tests/tools/system_mode.py
+++ b/tests/tools/system_mode.py
@@ -1,9 +1,10 @@
-import testbase
 import os
+import platform
 import time
 import unittest
-import platform
+
 import parse_cobertura
+import testbase
 
 
 class SystemModeBase(testbase.KcovTestCase):

--- a/tests/tools/system_mode.py
+++ b/tests/tools/system_mode.py
@@ -5,16 +5,18 @@ import unittest
 import platform
 import parse_cobertura
 
+
 class SystemModeBase(testbase.KcovTestCase):
     def writeToPipe(self, str):
         f = open("/tmp/kcov-system.pipe", "w")
         f.write(str)
         f.close()
 
+
 class system_mode_can_start_and_stop_daemon(SystemModeBase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov_system_daemon + " -d", False)
+        rv, o = self.do(testbase.kcov_system_daemon + " -d", False)
 
         pf = "/tmp/kcov-system.pid"
         assert os.path.isfile(pf)
@@ -25,10 +27,18 @@ class system_mode_can_start_and_stop_daemon(SystemModeBase):
 
         assert os.path.isfile(pf) == False
 
+
 class system_mode_can_instrument_binary(SystemModeBase):
     def runTest(self):
         self.setUp()
-        rv,o = self.do(testbase.kcov + " --system-record " + testbase.outbase + "/kcov " + testbase.testbuild + "/")
+        rv, o = self.do(
+            testbase.kcov
+            + " --system-record "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/"
+        )
         assert rv == 0
 
         src = testbase.testbuild + "/main-tests"
@@ -39,6 +49,7 @@ class system_mode_can_instrument_binary(SystemModeBase):
 
         assert os.path.getsize(dst) > os.path.getsize(src)
 
+
 class system_mode_can_record_and_report_binary(SystemModeBase):
     @unittest.skipIf(platform.machine() == "i686", "x86_64-only")
     def runTest(self):
@@ -48,12 +59,19 @@ class system_mode_can_record_and_report_binary(SystemModeBase):
             os.makedirs(testbase.outbase + "/kcov")
         except:
             pass
-        rv,o = self.do(testbase.kcov + " --system-record " + testbase.outbase + "/kcov " + testbase.testbuild + "/")
+        rv, o = self.do(
+            testbase.kcov
+            + " --system-record "
+            + testbase.outbase
+            + "/kcov "
+            + testbase.testbuild
+            + "/"
+        )
 
-        rv,o = self.do(testbase.kcov_system_daemon + " -d", False)
+        rv, o = self.do(testbase.kcov_system_daemon + " -d", False)
 
         os.environ["LD_LIBRARY_PATH"] = testbase.outbase + "/kcov/lib"
-        rv,o = self.do(testbase.outbase + "/kcov/main-tests", False)
+        rv, o = self.do(testbase.outbase + "/kcov/main-tests", False)
         print("Fickle test, ignoring")
         return
         assert rv == 0
@@ -61,7 +79,9 @@ class system_mode_can_record_and_report_binary(SystemModeBase):
         time.sleep(3)
         self.writeToPipe("STOPME")
 
-        rv,o = self.do(testbase.kcov + " --system-report " + testbase.outbase + "/kcov-report /tmp/kcov-data")
+        rv, o = self.do(
+            testbase.kcov + " --system-report " + testbase.outbase + "/kcov-report /tmp/kcov-data"
+        )
         assert rv == 0
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov-report/main-tests/cobertura.xml")

--- a/tests/tools/system_mode.py
+++ b/tests/tools/system_mode.py
@@ -26,7 +26,7 @@ class system_mode_can_start_and_stop_daemon(SystemModeBase):
 
         time.sleep(2)
 
-        assert os.path.isfile(pf) == False
+        assert os.path.isfile(pf) is False
 
 
 class system_mode_can_instrument_binary(SystemModeBase):
@@ -87,5 +87,5 @@ class system_mode_can_record_and_report_binary(SystemModeBase):
 
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov-report/main-tests/cobertura.xml")
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
-        assert parse_cobertura.hitsPerLine(dom, "main.cc", 14) == None
+        assert parse_cobertura.hitsPerLine(dom, "main.cc", 14) is None
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 18) >= 1

--- a/tests/tools/testbase.py
+++ b/tests/tools/testbase.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 
-import unittest
 import os
-import sys
-import subprocess
-import time
-import threading
 import platform
+import subprocess
+import sys
+import threading
+import unittest
 
 kcov = ""
 kcov_system_daemon = ""

--- a/tests/tools/testbase.py
+++ b/tests/tools/testbase.py
@@ -14,6 +14,7 @@ outbase = ""
 testbuild = ""
 sources = ""
 
+
 def configure(k, o, t, s):
     global kcov, outbase, testbuild, sources, kcov_system_daemon
     kcov = k
@@ -22,6 +23,7 @@ def configure(k, o, t, s):
     testbuild = t
     sources = s
 
+
 class KcovTestCase(unittest.TestCase):
     def setUp(self):
         if outbase != "":
@@ -29,27 +31,38 @@ class KcovTestCase(unittest.TestCase):
         os.system("/bin/mkdir -p %s/kcov/" % (outbase))
 
     def doShell(self, cmdline):
-        child = subprocess.Popen(cmdline, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        child = subprocess.Popen(
+            cmdline, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         out, err = child.communicate()
         output = out + err
         rv = child.returncode
 
         return rv, output
 
-    def do(self, cmdline, kcovKcov = True, timeout = None, kill = False):
+    def do(self, cmdline, kcovKcov=True, timeout=None, kill=False):
         output = ""
         rv = 0
 
         extra = ""
-        if kcovKcov and sys.platform.startswith("linux") and platform.machine() in ["x86_64", "i386", "i686"]:
-            extra = kcov + " --include-pattern=kcov --exclude-pattern=helper.cc,library.cc,html-data-files.cc " + outbase + "/kcov-kcov "
-
+        if (
+            kcovKcov
+            and sys.platform.startswith("linux")
+            and platform.machine() in ["x86_64", "i386", "i686"]
+        ):
+            extra = (
+                kcov
+                + " --include-pattern=kcov --exclude-pattern=helper.cc,library.cc,html-data-files.cc "
+                + outbase
+                + "/kcov-kcov "
+            )
 
         cmdline = extra + cmdline
         child = subprocess.Popen(cmdline.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         timer = None
 
         if timeout is not None:
+
             def stopChild():
                 print("\n  didn't finish within %s seconds; killing ..." % timeout)
                 if kill:


### PR DESCRIPTION
This is the first of a series of PR to improve the test suite readability and reliability.

  - [x] tests: ensure python 3.8
 
    This version supports features that will help improving the current
    implementation:
      * `subprocess.run`
      * fstring
      * positional-only parameters
        
    Update `tests.CMakeLists.txt` to find the Python3 package.
 
    Add the `ruff.toml` file.  Line lenght has been set to 100, and isort is
    enabled for lint.
     
    See also
      https://devguide.python.org/versions/

  - [x] tests: run "ruff format tests/tools"
 
    Run "ruff format tests/tools" and "ruff format tests/tools/run-tests"
         
    This commit changes a lot of code
        
    statistics:
      tests/tools/accumulate.py      | 166 +++++++++--
      tests/tools/bash.py            | 327 +++++++++++++++++++---
      tests/tools/bash_linux_only.py |  42 ++-
      tests/tools/basic.py           |  19 +-
      tests/tools/compiled.py        | 463 +++++++++++++++++++++++++------
      tests/tools/compiled_basic.py  |  81 +++++-
      tests/tools/filter.py          |  51 +++-
      tests/tools/parse_cobertura.py |  19 +-
      tests/tools/python.py          | 127 ++++++++-
      tests/tools/run-tests          |   6 +-
      tests/tools/system_mode.py     |  32 ++-
      tests/tools/testbase.py        |  23 +-
      12 files changed, 1153 insertions(+), 203 deletions(-)


  - [x] tests: run "ruff check --fix tests/tools"
 
    Run "ruff check --fix tests/tools" and
    "ruff check --fix tests/tools/run-tests"
     
    Apply safe fixes.

  - [x] tests: run "ruff check --fix --unsafe-fixes tests/tools"
 
    Run "ruff check --fix --unsafe-fixes tests/tools" and
    "ruff check --fix --unsafe-fixes tests/tools/run-tests" 
        
    Apply unsafe fixes. These are actually safe.
     
    These are additional errors reported by ruff:
  
      tests/tools/compiled.py:217:9: F821 Undefined name `self`
      tests/tools/compiled.py:321:9: E722 Do not use bare `except`
      tests/tools/compiled.py:685:9: F821 Undefined name `time`
      tests/tools/compiled.py:689:9: F821 Undefined name `time`
      tests/tools/system_mode.py:61:9: E722 Do not use bare `except`

Most of the code change has be done automatically.  Also note that some change are not optimal, but I avoided manual changes.

Since review will be very hard and you should not trust me, I suggest to @SimonKagstrom that

Only merge the first commit.
Add a commit for each of the following commands:
```console
> ruff format tests/tools
> ruff format tests/tools/run-tests
```

```console
> ruff check --fix tests/tools
> ruff check --fix tests/tools/run-tests
```

```console
> ruff format tests/tools
> ruff format tests/tools/run-tests
```

I used `ruff 0.3.3` but it should be ok to use a different version.

Formatting the code will make future changes more easy.
As an example, I plan to change how the command line is created for `subprocess`.
Currently is is a string, where arguments are concatenated together; it is terrible!