### PR TITLE
Improve tests code more

### DIFF
--- a/tests/tools/accumulate.py
+++ b/tests/tools/accumulate.py
@@ -1,4 +1,3 @@
-
 import parse_cobertura
 import testbase
 
@@ -200,9 +199,7 @@ class merge_coveralls(testbase.KcovTestCase):
             + "/tests/bash/shell-main"
         )
 
-        rv, o = self.doShell("grep second.py %s/kcov/main/coveralls.out" % (testbase.outbase))
+        rv, o = self.doShell(f"grep second.py {(testbase.outbase)}/kcov/main/coveralls.out")
         assert rv == 0
-        rv, o = self.doShell(
-            "grep shell-main %s/kcov/shell-main/coveralls.out" % (testbase.outbase)
-        )
+        rv, o = self.doShell(f"grep shell-main {(testbase.outbase)}/kcov/shell-main/coveralls.out")
         assert rv == 0

--- a/tests/tools/accumulate.py
+++ b/tests/tools/accumulate.py
@@ -4,7 +4,6 @@ import testbase
 
 class accumulate_data(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -35,7 +34,6 @@ class accumulate_data(testbase.KcovTestCase):
 
 class dont_accumulate_data_with_clean(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -66,7 +64,6 @@ class dont_accumulate_data_with_clean(testbase.KcovTestCase):
 
 class merge_basic(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -91,7 +88,6 @@ class merge_basic(testbase.KcovTestCase):
 
 class merge_multiple_output_directories(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -125,7 +121,6 @@ class merge_multiple_output_directories(testbase.KcovTestCase):
 
 class merge_merged_output(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -181,7 +176,6 @@ class merge_merged_output(testbase.KcovTestCase):
 
 class merge_coveralls(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --coveralls-id=dry-run "

--- a/tests/tools/bash.py
+++ b/tests/tools/bash.py
@@ -9,7 +9,6 @@ import testbase
 
 class BashBase(testbase.KcovTestCase):
     def doTest(self, args):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -25,7 +24,6 @@ class BashBase(testbase.KcovTestCase):
 
 class bash_coverage(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -57,7 +55,6 @@ class bash_coverage(testbase.KcovTestCase):
 # Very limited, will expand once it's working better
 class bash_coverage_debug_trap(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --bash-method=DEBUG "
@@ -75,7 +72,6 @@ class bash_coverage_debug_trap(testbase.KcovTestCase):
 
 class bash_short_file(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -129,7 +125,6 @@ class bash_coverage_tricky(BashBase):
 
 class bash_honor_signal(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.sources
             + "/tests/setpgid-kill/test-script.sh "
@@ -148,7 +143,6 @@ class bash_honor_signal(testbase.KcovTestCase):
 
 class bash_accumulate_data(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -179,7 +173,6 @@ class bash_accumulate_changed_data(testbase.KcovTestCase):
     # Not sure why, but for now...
     @unittest.skipUnless(platform.machine() in ["x86_64", "i686", "i386"], "Only for x86")
     def runTest(self):
-        self.setUp()
         os.system("mkdir -p /tmp/test-kcov")
         os.system("cp " + testbase.sources + "/tests/bash/shell-main /tmp/test-kcov")
         os.system("cp " + testbase.sources + "/tests/bash/other.sh /tmp/test-kcov")
@@ -204,7 +197,6 @@ class bash_accumulate_changed_data(testbase.KcovTestCase):
 
 class bash_merge_data_issue_38(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -247,7 +239,6 @@ class bash_merge_data_issue_38(testbase.KcovTestCase):
 
 class bash_issue_116_arithmetic_and_heredoc_issue_117_comment_within_string(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -266,7 +257,6 @@ class bash_issue_116_arithmetic_and_heredoc_issue_117_comment_within_string(test
 
 class bash_multiline_quotes(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -283,7 +273,6 @@ class bash_multiline_quotes(testbase.KcovTestCase):
 
 class bash_multiline_backslashes(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -298,7 +287,6 @@ class bash_multiline_backslashes(testbase.KcovTestCase):
 
 class bash_no_executed_lines(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -317,7 +305,6 @@ class bash_no_executed_lines(testbase.KcovTestCase):
 
 class bash_stderr_redirection(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -341,7 +328,6 @@ class bash_stderr_redirection(testbase.KcovTestCase):
 
 class bash_dollar_var_replacement(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -362,7 +348,6 @@ class bash_dollar_var_replacement(testbase.KcovTestCase):
 # Issue #152
 class bash_done_eof(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -379,7 +364,6 @@ class bash_done_eof(testbase.KcovTestCase):
 # Issue #154
 class bash_eof_backtick(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -429,7 +413,6 @@ class bash_handle_all_output(testbase.KcovTestCase):
 
 class bash_exit_status(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.sources + "/tests/bash/shell-main 5", False)
         rv, o = self.do(
             testbase.kcov
@@ -446,7 +429,6 @@ class bash_exit_status(testbase.KcovTestCase):
 # Issue 180
 class bash_ignore_uncovered(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --exclude-region=CUSTOM_RANGE_START:CUSTOM_RANGE_END "
@@ -487,7 +469,6 @@ class bash_ignore_uncovered(testbase.KcovTestCase):
 # Issue #224
 class bash_can_find_non_executed_scripts(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -505,7 +486,6 @@ class bash_can_find_non_executed_scripts(testbase.KcovTestCase):
 
 class bash_can_find_non_executed_scripts_manually(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --bash-parse-files-in-dir="
@@ -525,7 +505,6 @@ class bash_can_find_non_executed_scripts_manually(testbase.KcovTestCase):
 
 class bash_can_ignore_non_executed_scripts(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --bash-dont-parse-binary-dir "

--- a/tests/tools/bash_linux_only.py
+++ b/tests/tools/bash_linux_only.py
@@ -4,7 +4,6 @@ import testbase
 
 class bash_sh_shebang(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --bash-handle-sh-invocation "

--- a/tests/tools/bash_linux_only.py
+++ b/tests/tools/bash_linux_only.py
@@ -1,4 +1,3 @@
-
 import parse_cobertura
 import testbase
 

--- a/tests/tools/basic.py
+++ b/tests/tools/basic.py
@@ -7,7 +7,6 @@ import testbase
 
 class TooFewArguments(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, output = self.do(testbase.kcov + " " + testbase.outbase + "/kcov")
 
         assert b"Usage: kcov" in output
@@ -16,7 +15,6 @@ class TooFewArguments(testbase.KcovTestCase):
 
 class WrongArguments(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, output = self.do(
             testbase.kcov
             + " --abc=efg "
@@ -33,7 +31,6 @@ class WrongArguments(testbase.KcovTestCase):
 class LookupBinaryInPath(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
         os.environ["PATH"] += testbase.sources + "/tests/python"
         noKcovRv, o = self.do(testbase.sources + "/tests/python/main 5")
         rv, o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov " + "main 5")
@@ -46,7 +43,6 @@ class LookupBinaryInPath(testbase.KcovTestCase):
 # Issue #414
 class OutDirectoryIsExecutable(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         # Running a system executable on Linux may cause ptrace to fails with
         # "Operation not permitted", even with ptrace_scope set to 0.
         # See https://www.kernel.org/doc/Documentation/security/Yama.txt

--- a/tests/tools/compiled.py
+++ b/tests/tools/compiled.py
@@ -223,7 +223,6 @@ class SignalsBase(testbase.KcovTestCase):
         return parse_cobertura.parseFile(testbase.outbase + "/kcov/signals/cobertura.xml")
 
     def doTest(self):
-
         dom = self.cmpOne("hup")
         assert parse_cobertura.hitsPerLine(dom, "test-signals.c", 14) == 1
 
@@ -560,7 +559,6 @@ class debuglink(testbase.KcovTestCase):
 class collect_no_source(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
-
         os.system(f"cp {testbase.sources}/tests/short-file.c {testbase.testbuild}/main.cc")
         os.system(f"gcc -g -o {testbase.testbuild}/main-collect-only {testbase.testbuild}/main.cc")
         os.system(f"mv {testbase.testbuild}/main.cc {testbase.testbuild}/tmp-main.cc")

--- a/tests/tools/compiled.py
+++ b/tests/tools/compiled.py
@@ -11,7 +11,6 @@ class illegal_insn(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     @unittest.skipUnless(platform.machine() in ["x86_64", "i686", "i386"], "Only for x86")
     def runTest(self):
-        self.setUp()
         rv, output = self.do(
             testbase.kcov
             + " "
@@ -28,7 +27,6 @@ class illegal_insn(testbase.KcovTestCase):
 class fork_no_wait(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/fork_no_wait", False)
         rv, o = self.do(
             testbase.kcov
@@ -49,7 +47,6 @@ class fork_no_wait(testbase.KcovTestCase):
 
 class ForkBase(testbase.KcovTestCase):
     def doTest(self, binary):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/" + binary, False)
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/" + binary,
@@ -86,7 +83,6 @@ class vfork(testbase.KcovTestCase):
         "Not for OSX (does not work with the mach-engine for now)",
     )
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/vfork", False
         )
@@ -100,7 +96,6 @@ class vfork(testbase.KcovTestCase):
 class popen_test(testbase.KcovTestCase):
     @unittest.skipUnless(platform.machine() in ["x86_64", "i686", "i386"], "Only for x86")
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/test_popen", False)
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/test_popen",
@@ -114,14 +109,12 @@ class popen_test(testbase.KcovTestCase):
 class short_filename(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
         rv, o = self.do(testbase.kcov + " " + testbase.outbase + "/kcov ./s", False)
         assert rv == 99
 
 
 class Pie(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/pie", False)
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie", False
@@ -134,7 +127,6 @@ class Pie(testbase.KcovTestCase):
 
 class pie_argv_basic(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie-test",
             False,
@@ -152,7 +144,6 @@ class pie_accumulate(testbase.KcovTestCase):
         "Not for OSX (does not work with the mach-engine for now)",
     )
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/pie-test",
             False,
@@ -176,7 +167,6 @@ class pie_accumulate(testbase.KcovTestCase):
 
 class global_ctors(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/global-constructors", False)
         rv, o = self.do(
             testbase.kcov
@@ -199,7 +189,6 @@ class daemon_wait_for_last_child(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #158")
     @unittest.skipUnless(platform.machine() in ["x86_64", "i686", "i386"], "Only for x86")
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/test_daemon", False)
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/test_daemon",
@@ -235,7 +224,6 @@ class SignalsBase(testbase.KcovTestCase):
         return parse_cobertura.parseFile(testbase.outbase + "/kcov/signals/cobertura.xml")
 
     def doTest(self):
-        self.setUp()
 
         dom = self.cmpOne("hup")
         assert parse_cobertura.hitsPerLine(dom, "test-signals.c", 14) == 1
@@ -272,7 +260,6 @@ class signals_self(SignalsBase):
 class signals_crash(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX (macho-parser for now)")
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -300,7 +287,6 @@ class collect_and_report_only(testbase.KcovTestCase):
     # Cannot work with combined Engine / Parser
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/main-tests ", False)
         rv, o = self.do(
             testbase.kcov
@@ -337,7 +323,6 @@ class collect_and_report_only(testbase.KcovTestCase):
 
 class setpgid_kill(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(
             testbase.sources
             + "/tests/setpgid-kill/test-script.sh "
@@ -363,7 +348,6 @@ class setpgid_kill(testbase.KcovTestCase):
 class attach_process_with_threads(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.sources
             + "/tests/daemon/test-script.sh "
@@ -386,7 +370,6 @@ class attach_process_with_threads(testbase.KcovTestCase):
 class attach_process_with_threads_creates_threads(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.sources
             + "/tests/daemon/test-script.sh "
@@ -407,7 +390,6 @@ class attach_process_with_threads_creates_threads(testbase.KcovTestCase):
 
 class merge_same_file_in_multiple_binaries(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/multi_1",
             False,
@@ -437,7 +419,6 @@ class merge_same_file_in_multiple_binaries(testbase.KcovTestCase):
 class debuglink(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
-        self.setUp()
         os.system(f"rm -rf {(testbase.outbase)}/.debug")
         os.system(f"cp {testbase.testbuild}/main-tests {testbase.testbuild}/main-tests-debug-file")
         os.system(
@@ -583,7 +564,6 @@ class debuglink(testbase.KcovTestCase):
 class collect_no_source(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
 
         os.system(f"cp {testbase.sources}/tests/short-file.c {testbase.testbuild}/main.cc")
         os.system(f"gcc -g -o {testbase.testbuild}/main-collect-only {testbase.testbuild}/main.cc")
@@ -616,7 +596,6 @@ class collect_no_source(testbase.KcovTestCase):
 class dlopen(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/dlopen", False)
         rv, o = self.do(
             testbase.kcov + " " + testbase.outbase + "/kcov " + testbase.testbuild + "/dlopen",
@@ -634,7 +613,6 @@ class dlopen(testbase.KcovTestCase):
 class dlopen_in_ignored_source_file(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --exclude-pattern=dlopen.cc "
@@ -654,7 +632,6 @@ class daemon_no_wait_for_last_child(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/test_daemon", False)
         rv, o = self.do(
             testbase.kcov
@@ -680,7 +657,6 @@ class address_sanitizer_coverage(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
         if not os.path.isfile(testbase.testbuild + "/sanitizer-coverage"):
             print("Clang-only")
             assert False

--- a/tests/tools/compiled.py
+++ b/tests/tools/compiled.py
@@ -72,8 +72,7 @@ class fork_32(ForkBase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     @unittest.skipUnless(platform.machine().startswith("x86_64"), "Only for x86_64")
     def runTest(self):
-        print("Fickle test, ignoring")
-        return
+        self.skipTest("Fickle test, ignoring")
         self.doTest("fork-32")
 
 
@@ -297,8 +296,7 @@ class collect_and_report_only(testbase.KcovTestCase):
             + "/main-tests",
             False,
         )
-        print("Fickle test, ignoring")
-        return
+        self.skipTest("Fickle test, ignoring")
         assert rv == noKcovRv
 
         try:
@@ -360,8 +358,7 @@ class attach_process_with_threads(testbase.KcovTestCase):
             False,
         )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/issue31/cobertura.xml")
-        print("Fickle test, ignoring")
-        return
+        self.skipTest("Fickle test, ignoring")
         assert parse_cobertura.hitsPerLine(dom, "test-issue31.cc", 28) >= 1
         assert parse_cobertura.hitsPerLine(dom, "test-issue31.cc", 11) >= 1
         assert parse_cobertura.hitsPerLine(dom, "test-issue31.cc", 9) == 0
@@ -382,8 +379,7 @@ class attach_process_with_threads_creates_threads(testbase.KcovTestCase):
             False,
         )
         dom = parse_cobertura.parseFile(testbase.outbase + "/kcov/thread-test/cobertura.xml")
-        print("Fickle test, ignoring")
-        return
+        self.skipTest("Fickle test, ignoring")
         assert parse_cobertura.hitsPerLine(dom, "thread-main.c", 21) >= 1
         assert parse_cobertura.hitsPerLine(dom, "thread-main.c", 9) >= 1
 

--- a/tests/tools/compiled.py
+++ b/tests/tools/compiled.py
@@ -438,57 +438,44 @@ class debuglink(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
     def runTest(self):
         self.setUp()
-        os.system("rm -rf %s/.debug" % (testbase.outbase))
+        os.system(f"rm -rf {(testbase.outbase)}/.debug")
+        os.system(f"cp {testbase.testbuild}/main-tests {testbase.testbuild}/main-tests-debug-file")
         os.system(
-            "cp %s/main-tests %s/main-tests-debug-file" % (testbase.testbuild, testbase.testbuild)
+            f"objcopy --only-keep-debug {testbase.testbuild}/main-tests-debug-file {testbase.testbuild}/main-tests-debug-file.debug"
         )
         os.system(
-            "objcopy --only-keep-debug %s/main-tests-debug-file %s/main-tests-debug-file.debug"
-            % (testbase.testbuild, testbase.testbuild)
+            f"cp {testbase.testbuild}/main-tests-debug-file.debug {testbase.testbuild}/main-tests-debug-file1.debug"
         )
         os.system(
-            "cp %s/main-tests-debug-file.debug %s/main-tests-debug-file1.debug"
-            % (testbase.testbuild, testbase.testbuild)
+            f"cp {testbase.testbuild}/main-tests-debug-file.debug {testbase.testbuild}/main-tests-debug-file12.debug"
         )
         os.system(
-            "cp %s/main-tests-debug-file.debug %s/main-tests-debug-file12.debug"
-            % (testbase.testbuild, testbase.testbuild)
+            f"cp {testbase.testbuild}/main-tests-debug-file.debug {testbase.testbuild}/main-tests-debug-file123.debug"
         )
         os.system(
-            "cp %s/main-tests-debug-file.debug %s/main-tests-debug-file123.debug"
-            % (testbase.testbuild, testbase.testbuild)
+            f"cp {testbase.testbuild}/main-tests-debug-file {testbase.testbuild}/main-tests-debug-file1"
         )
         os.system(
-            "cp %s/main-tests-debug-file %s/main-tests-debug-file1"
-            % (testbase.testbuild, testbase.testbuild)
+            f"cp {testbase.testbuild}/main-tests-debug-file {testbase.testbuild}/main-tests-debug-file2"
         )
         os.system(
-            "cp %s/main-tests-debug-file %s/main-tests-debug-file2"
-            % (testbase.testbuild, testbase.testbuild)
+            f"cp {testbase.testbuild}/main-tests-debug-file {testbase.testbuild}/main-tests-debug-file3"
+        )
+        os.system(f"strip -g {(testbase.testbuild)}/main-tests-debug-file")
+        os.system(f"strip -g {(testbase.testbuild)}/main-tests-debug-file1")
+        os.system(f"strip -g {(testbase.testbuild)}/main-tests-debug-file2")
+        os.system(f"strip -g {(testbase.testbuild)}/main-tests-debug-file3")
+        os.system(
+            f"objcopy --add-gnu-debuglink={testbase.testbuild}/main-tests-debug-file.debug {testbase.testbuild}/main-tests-debug-file"
         )
         os.system(
-            "cp %s/main-tests-debug-file %s/main-tests-debug-file3"
-            % (testbase.testbuild, testbase.testbuild)
-        )
-        os.system("strip -g %s/main-tests-debug-file" % (testbase.testbuild))
-        os.system("strip -g %s/main-tests-debug-file1" % (testbase.testbuild))
-        os.system("strip -g %s/main-tests-debug-file2" % (testbase.testbuild))
-        os.system("strip -g %s/main-tests-debug-file3" % (testbase.testbuild))
-        os.system(
-            "objcopy --add-gnu-debuglink=%s/main-tests-debug-file.debug %s/main-tests-debug-file"
-            % (testbase.testbuild, testbase.testbuild)
+            f"objcopy --add-gnu-debuglink={testbase.testbuild}/main-tests-debug-file1.debug {testbase.testbuild}/main-tests-debug-file1"
         )
         os.system(
-            "objcopy --add-gnu-debuglink=%s/main-tests-debug-file1.debug %s/main-tests-debug-file1"
-            % (testbase.testbuild, testbase.testbuild)
+            f"objcopy --add-gnu-debuglink={testbase.testbuild}/main-tests-debug-file12.debug {testbase.testbuild}/main-tests-debug-file2"
         )
         os.system(
-            "objcopy --add-gnu-debuglink=%s/main-tests-debug-file12.debug %s/main-tests-debug-file2"
-            % (testbase.testbuild, testbase.testbuild)
-        )
-        os.system(
-            "objcopy --add-gnu-debuglink=%s/main-tests-debug-file123.debug %s/main-tests-debug-file3"
-            % (testbase.testbuild, testbase.testbuild)
+            f"objcopy --add-gnu-debuglink={testbase.testbuild}/main-tests-debug-file123.debug {testbase.testbuild}/main-tests-debug-file3"
         )
 
         noKcovRv, o = self.do(testbase.testbuild + "/main-tests-debug-file", False)
@@ -552,10 +539,10 @@ class debuglink(testbase.KcovTestCase):
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
 
         # Look in .debug
-        os.system("rm -rf %s/kcov" % (testbase.outbase))
-        os.system("mkdir -p %s/.debug" % (testbase.testbuild))
+        os.system(f"rm -rf {(testbase.outbase)}/kcov")
+        os.system(f"mkdir -p {(testbase.testbuild)}/.debug")
         os.system(
-            "mv %s/main-tests-debug-file.debug %s/.debug" % (testbase.testbuild, testbase.testbuild)
+            f"mv {testbase.testbuild}/main-tests-debug-file.debug {testbase.testbuild}/.debug"
         )
 
         rv, o = self.do(
@@ -572,8 +559,8 @@ class debuglink(testbase.KcovTestCase):
         )
         assert parse_cobertura.hitsPerLine(dom, "main.cc", 9) == 1
 
-        os.system("rm -rf %s/kcov" % (testbase.outbase))
-        os.system("echo 'abc' >> %s/.debug/main-tests-debug-file.debug" % (testbase.testbuild))
+        os.system(f"rm -rf {(testbase.outbase)}/kcov")
+        os.system(f"echo 'abc' >> {(testbase.testbuild)}/.debug/main-tests-debug-file.debug")
 
         rv, o = self.do(
             testbase.kcov
@@ -598,11 +585,9 @@ class collect_no_source(testbase.KcovTestCase):
     def runTest(self):
         self.setUp()
 
-        os.system("cp %s/tests/short-file.c %s/main.cc" % (testbase.sources, testbase.testbuild))
-        os.system(
-            "gcc -g -o %s/main-collect-only %s/main.cc" % (testbase.testbuild, testbase.testbuild)
-        )
-        os.system("mv %s/main.cc %s/tmp-main.cc" % (testbase.testbuild, testbase.testbuild))
+        os.system(f"cp {testbase.sources}/tests/short-file.c {testbase.testbuild}/main.cc")
+        os.system(f"gcc -g -o {testbase.testbuild}/main-collect-only {testbase.testbuild}/main.cc")
+        os.system(f"mv {testbase.testbuild}/main.cc {testbase.testbuild}/tmp-main.cc")
 
         rv, o = self.do(
             testbase.kcov
@@ -614,7 +599,7 @@ class collect_no_source(testbase.KcovTestCase):
             False,
         )
 
-        os.system("mv %s/tmp-main.cc %s/main.cc" % (testbase.testbuild, testbase.testbuild))
+        os.system(f"mv {testbase.testbuild}/tmp-main.cc {testbase.testbuild}/main.cc")
         rv, o = self.do(
             testbase.kcov
             + " --report-only "

--- a/tests/tools/compiled_basic.py
+++ b/tests/tools/compiled_basic.py
@@ -97,7 +97,6 @@ class shared_library_accumulate(testbase.KcovTestCase):
 
 class MainTestBase(testbase.KcovTestCase):
     def doTest(self, verify):
-
         noKcovRv, o = self.do(testbase.testbuild + "/main-tests", False)
         rv, o = self.do(
             testbase.kcov

--- a/tests/tools/compiled_basic.py
+++ b/tests/tools/compiled_basic.py
@@ -11,7 +11,6 @@ class shared_library(testbase.KcovTestCase):
         "Not for OSX (does not work with the mach-engine for now)",
     )
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.testbuild + "/shared_library_test", False)
         rv, o = self.do(
             testbase.kcov
@@ -34,7 +33,6 @@ class shared_library(testbase.KcovTestCase):
 class shared_library_skip(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #157")
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --skip-solibs "
@@ -58,7 +56,6 @@ class shared_library_skip(testbase.KcovTestCase):
 class shared_library_filter_out(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #157")
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --exclude-pattern=solib "
@@ -80,7 +77,6 @@ class shared_library_filter_out(testbase.KcovTestCase):
 class shared_library_accumulate(testbase.KcovTestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX, Issue #157")
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -102,7 +98,6 @@ class shared_library_accumulate(testbase.KcovTestCase):
 
 class MainTestBase(testbase.KcovTestCase):
     def doTest(self, verify):
-        self.setUp()
 
         noKcovRv, o = self.do(testbase.testbuild + "/main-tests", False)
         rv, o = self.do(

--- a/tests/tools/compiled_basic.py
+++ b/tests/tools/compiled_basic.py
@@ -42,8 +42,7 @@ class shared_library_skip(testbase.KcovTestCase):
             + "/shared_library_test",
             False,
         )
-        print("Fickle test, ignoring")
-        return
+        self.skipTest("Fickle test, ignoring")
         assert rv == 0
 
         dom = parse_cobertura.parseFile(

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -1,4 +1,3 @@
-
 import parse_cobertura
 import testbase
 

--- a/tests/tools/filter.py
+++ b/tests/tools/filter.py
@@ -4,7 +4,6 @@ import testbase
 
 class include_exclude_pattern(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --bash-dont-parse-binary-dir --exclude-pattern=first-dir "
@@ -46,7 +45,6 @@ class include_exclude_pattern(testbase.KcovTestCase):
 
 class include_path(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --bash-dont-parse-binary-dir --include-path="
@@ -66,7 +64,6 @@ class include_path(testbase.KcovTestCase):
 
 class include_path_and_exclude_pattern(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --bash-dont-parse-binary-dir --include-path="

--- a/tests/tools/python.py
+++ b/tests/tools/python.py
@@ -6,7 +6,6 @@ import testbase
 
 class python_exit_status(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         noKcovRv, o = self.do(testbase.sources + "/tests/python/main 5")
         rv, o = self.do(
             testbase.kcov
@@ -22,7 +21,6 @@ class python_exit_status(testbase.KcovTestCase):
 
 class python_can_set_illegal_parser(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --python-parser=python7 "
@@ -37,7 +35,6 @@ class python_can_set_illegal_parser(testbase.KcovTestCase):
 
 class python_can_set_legal_parser(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --python-parser=python3 "
@@ -52,7 +49,6 @@ class python_can_set_legal_parser(testbase.KcovTestCase):
 
 class python2_can_set_legal_parser(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --python-parser=python2 "
@@ -67,7 +63,6 @@ class python2_can_set_legal_parser(testbase.KcovTestCase):
 
 class python_issue_368_can_handle_symlink_target(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --python-parser=python3 "
@@ -82,7 +77,6 @@ class python_issue_368_can_handle_symlink_target(testbase.KcovTestCase):
 
 class python_unittest(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -98,7 +92,6 @@ class python_unittest(testbase.KcovTestCase):
 
 class PythonBase(testbase.KcovTestCase):
     def doTest(self, extra):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -135,7 +128,6 @@ class python_coverage(PythonBase):
 
 class python_accumulate_data(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -174,7 +166,6 @@ class python2_coverage(PythonBase):
 
 class python_tricky_single_line_string_assignment(testbase.KcovTestCase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "
@@ -190,7 +181,6 @@ class python_tricky_single_line_string_assignment(testbase.KcovTestCase):
 
 class python_select_parser(testbase.KcovTestCase):
     def disabledTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --python-parser="
@@ -208,7 +198,6 @@ class python_select_parser(testbase.KcovTestCase):
 class python_tricky_single_dict_assignment(testbase.KcovTestCase):
     @unittest.expectedFailure
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " "

--- a/tests/tools/system_mode.py
+++ b/tests/tools/system_mode.py
@@ -16,7 +16,6 @@ class SystemModeBase(testbase.KcovTestCase):
 
 class system_mode_can_start_and_stop_daemon(SystemModeBase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(testbase.kcov_system_daemon + " -d", False)
 
         pf = "/tmp/kcov-system.pid"
@@ -31,7 +30,6 @@ class system_mode_can_start_and_stop_daemon(SystemModeBase):
 
 class system_mode_can_instrument_binary(SystemModeBase):
     def runTest(self):
-        self.setUp()
         rv, o = self.do(
             testbase.kcov
             + " --system-record "
@@ -55,7 +53,6 @@ class system_mode_can_record_and_report_binary(SystemModeBase):
     @unittest.skipIf(platform.machine() == "i686", "x86_64-only")
     def runTest(self):
         print(platform.machine())
-        self.setUp()
         try:
             os.makedirs(testbase.outbase + "/kcov")
         except:

--- a/tests/tools/system_mode.py
+++ b/tests/tools/system_mode.py
@@ -70,8 +70,7 @@ class system_mode_can_record_and_report_binary(SystemModeBase):
 
         os.environ["LD_LIBRARY_PATH"] = testbase.outbase + "/kcov/lib"
         rv, o = self.do(testbase.outbase + "/kcov/main-tests", False)
-        print("Fickle test, ignoring")
-        return
+        self.skipTest("Fickle test, ignoring")
         assert rv == 0
 
         time.sleep(3)

--- a/tests/tools/testbase.py
+++ b/tests/tools/testbase.py
@@ -66,8 +66,7 @@ class KcovTestCase(unittest.TestCase):
             extra = (
                 kcov
                 + " --include-pattern=kcov --exclude-pattern=helper.cc,library.cc,html-data-files.cc "
-                + outbase
-                + "/kcov-kcov "
+                + "/tmp/kcov-kcov "
             )
 
         cmdline = extra + cmdline

--- a/tests/tools/testbase.py
+++ b/tests/tools/testbase.py
@@ -3,6 +3,7 @@
 import os
 import os.path
 import platform
+import shutil
 import subprocess
 import sys
 import threading
@@ -37,9 +38,10 @@ def configure(k, o, t, s):
 
 class KcovTestCase(unittest.TestCase):
     def setUp(self):
-        if outbase != "":
-            os.system(f"/bin/rm -rf {(outbase)}/kcov")
-        os.system(f"/bin/mkdir -p {(outbase)}/kcov/")
+        os.makedirs(outbase + "/" + "kcov")
+
+    def tearDown(self):
+        shutil.rmtree(outbase + "/" + "kcov")
 
     def doShell(self, cmdline):
         child = subprocess.Popen(

--- a/tests/tools/testbase.py
+++ b/tests/tools/testbase.py
@@ -38,8 +38,8 @@ def configure(k, o, t, s):
 class KcovTestCase(unittest.TestCase):
     def setUp(self):
         if outbase != "":
-            os.system("/bin/rm -rf %s/kcov" % (outbase))
-        os.system("/bin/mkdir -p %s/kcov/" % (outbase))
+            os.system(f"/bin/rm -rf {(outbase)}/kcov")
+        os.system(f"/bin/mkdir -p {(outbase)}/kcov/")
 
     def doShell(self, cmdline):
         child = subprocess.Popen(
@@ -75,7 +75,7 @@ class KcovTestCase(unittest.TestCase):
         if timeout is not None:
 
             def stopChild():
-                print("\n  didn't finish within %s seconds; killing ..." % timeout)
+                print(f"\n  didn't finish within {timeout} seconds; killing ...")
                 if kill:
                     child.kill()
                 else:

--- a/tests/tools/testbase.py
+++ b/tests/tools/testbase.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import os.path
 import platform
 import subprocess
 import sys
@@ -14,13 +15,24 @@ testbuild = ""
 sources = ""
 
 
+# Normalize path, also ensuring that it is not empty.
+def normalize(path):
+    assert len(path) != 0, "path must be not empty"
+
+    path = os.path.normpath(path)
+    return path
+
+
 def configure(k, o, t, s):
     global kcov, outbase, testbuild, sources, kcov_system_daemon
-    kcov = k
+
+    kcov = normalize(k)
     kcov_system_daemon = k + "-system-daemon"
-    outbase = o
-    testbuild = t
-    sources = s
+    outbase = normalize(o)
+    testbuild = normalize(t)
+    sources = normalize(s)
+
+    assert os.path.abspath(outbase) != os.getcwd(), "'outbase' cannot be the current directory"
 
 
 class KcovTestCase(unittest.TestCase):


### PR DESCRIPTION
 Additional improvements to `kcov` test suite.

  - [x] tests: validate `testbase.configure` arguments
    
    Ensure that all the paths in `testbase.configure` are not empty and
    normalized.
    
    Ensure that `outbase` is not the current working directory.

  - [x] tests: convert simple % style string format to f-string
    
    Convert old formatting style to f-string style, using
    `python3 -m libcst.tool codemod convert_percent_format_to_fstring.ConvertPercentFormatStringCommand`

  - [x] tests: remove unnecessary call to `setUp` method.
    
    It is not necessary because `setUp` is called automatically by
    `TestCase.run`.

  - [x] tests: use `skipTest` instead of print and return
    
    Using `skipTest` is the preferred method for skipping tests.
    Now the test message is printed on the same line.

  - [x] tests: override `TestCase.tearDown` in `testbase.py`
    
    Use `os.makedirs` to create the `kcov` directory in `setUp` and `shutil.rmtree`
    to remove it in `tearDown`.
    
    Don't use the shell, since errors are not propagated.

  - [x] Ensure the "kcov-kcov" directory uses a fixed path
    
    In `ci.yml`, `codecov` assumes that the output directory is
    "/tmp/kcov-kcov".

    Don't assume that `outbase` is always "/tmp", and instead use the
    "/tmp/kcov-kcov" path.

## NOTES

  * I used tools to automate refactoring, like `LibCST` and `sed`.

  * LibCTS codemod for converting old format to f-string unfortunately added parenthesis in some non simple statement.  Only later I found that there was another tool `flynt` but I have not used it to see if there are differences in formatting.

  * When removing calls to `setUp` method, I also inadvertently removed calls to `setUp` method inside the `doTest` method.  This is fine, since `doTest` is always called from the `runTest` method so `setUp` is always called.


## TODO

I noted that `doShell` is used only two times; other code using the shell use `system`.

Additionally, both `doShell` and `system` **does not** propagate errors, so I plan to make this more robust in a separate PR.  I also plan to group shell commands, instead of spawning a subprocess for every command line.