### PR TITLE
Improve tests code even more

### DIFF
--- a/tests/tools/bash_linux_only.py
+++ b/tests/tools/bash_linux_only.py
@@ -29,7 +29,6 @@ class bash_exit_before_child(testbase.KcovTestCase):
             + "/tests/bash/background-child.sh",
             kcovKcov=False,
             timeout=3.0,
-            kill=True,
         )
         self.assertEqual(0, rv, "kcov exited unsuccessfully")
         dom = parse_cobertura.parseFile(


### PR DESCRIPTION
Additional improvements to kcov test suite.

## IMPORTANT

This PR is not ready to be merged.

## CHANGES

  - [x] Additional improvements to kcov test suite.
    The current, old API, is not only inconvenient (using a thread and a timer to implement timeouts) but it is also incorrect since the child process is not waited.
    
    Use subprocess.run for both `doShell` and `do`.  Note that for the `do` method, this is a behavior change, since a child process is always terminated by kill.
    
    Add a default timeout, set to 10 min.
    
    After this change the test `system_mode_can_record_and_report_binary` fails.  This will be addressed in the next commit.


