### PR TITLE
workflows: fix ci-run-tests.sh script

### DIFF
--- a/.github/workflows/ci-run-tests.sh
+++ b/.github/workflows/ci-run-tests.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 run () {
-  tests/tools/run-tests build/src/kcov /tmp/ build-tests/ `pwd` -v || exit 64
+  tests/tools/run-tests build/src/kcov /tmp/ build-tests/ "." -v "$@" || exit 64
 }
 
 run "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         if: ${{ matrix.arch == 'amd64' }}
         run: |
           sudo .github/workflows/generic-build.sh ${{ matrix.arch }}
-          sudo .github/workflows/ci-run-tests.sh ${{ matrix.arch }}
+          sudo .github/workflows/ci-run-tests.sh
           wget https://codecov.io/bash || true
           bash bash -s /tmp/kcov-kcov || true
 


### PR DESCRIPTION
The run function is incorrect, since it does not accept additional arguments.

Don't use `pwd` for sources directory, since all other paths, excluding /tmp, are relative.

Update the ci.yml workflow, removing the "amd64" argument to the ci-run-tests.sh script.  It was working because the argument was ignored.

@SimonKagstrom, the change from "`pwd`" to `"."` may be controversial.  Let me know what you think.  I use it in my `test.sh` script, when testing locally.