### PR TITLE
Improve ci

### DIFF
--- a/.github/workflows/ci-run-tests.sh
+++ b/.github/workflows/ci-run-tests.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 run () {
   export PYTHONPATH=tests/tools
-  python -m libkcov build/src/kcov /tmp/ build-tests/ "." -v "$@" || exit 64
+  python3 -m libkcov build/src/kcov /tmp/ build-tests/ "." -v "$@" || exit 64
 }
 
 run "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
     name: Build and test Linux executable
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         arch: [amd64, armv7, aarch64, ppc64le, i386]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build for matrix.arch == armv7, aarch64, ppc64le
         if: ${{ matrix.arch == 'armv7' || matrix.arch == 'aarch64' || matrix.arch == 'ppc64le' }}
-        uses: uraimo/run-on-arch-action@v2.6.0
+        uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{ matrix.arch }}
           distro: ubuntu22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Build for OSX
         run: |
           sudo .github/workflows/osx-build.sh
-
+          sudo .github/workflows/ci-run-tests.sh
 
   build-freebsd:
     runs-on: ubuntu-22.04

--- a/.github/workflows/freebsd-build.sh
+++ b/.github/workflows/freebsd-build.sh
@@ -13,7 +13,7 @@ run () {
   cd ..
 
   cd build-tests
-  cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../tests || exit 64
+  cmake ../tests || exit 64
   make || exit 64
   cd ..
 

--- a/.github/workflows/freebsd-build.sh
+++ b/.github/workflows/freebsd-build.sh
@@ -5,11 +5,13 @@ set -euo pipefail
 run () {
   export PATH="${PATH}:${HOME}/kcov/bin"
   mkdir build build-tests
+
   cd build
   cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. || exit 64
   make || exit 64
   make install || exit 64
   cd ..
+
   cd build-tests
   cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../tests || exit 64
   make || exit 64

--- a/.github/workflows/generic-build.sh
+++ b/.github/workflows/generic-build.sh
@@ -30,7 +30,7 @@ run () {
   cd ..
 
   cd build-tests
-  cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../tests || exit 64
+  cmake ../tests || exit 64
   make || exit 64
   cd ..
 

--- a/.github/workflows/generic-build.sh
+++ b/.github/workflows/generic-build.sh
@@ -19,17 +19,21 @@ run () {
   apt-mark hold php* google* libobjc* libpq* libidn* postgresql* python3-httplib2 samba* >/dev/null
   apt-get upgrade -y
   apt-get install -y binutils-dev libcurl4-openssl-dev libdw-dev libiberty-dev gcc g++ make cmake libssl-dev git python3 python2 $EXTRA_PACKAGES
+
   export PATH="${PATH}:${HOME}/kcov/bin"
   mkdir build build-tests
+
   cd build
   cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. || exit 64
   make || exit 64
   make install || exit 64
   cd ..
+
   cd build-tests
   cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../tests || exit 64
   make || exit 64
   cd ..
+
   tar czf kcov-"$1".tar.gz /usr/local/bin/kcov* /usr/local/share/doc/kcov/* /usr/local/share/man/man1/kcov.1
   readelf -h /usr/local/bin/kcov
   if [[ -e "kcov-$1.tar.gz" ]]; then

--- a/.github/workflows/osx-build.sh
+++ b/.github/workflows/osx-build.sh
@@ -5,11 +5,13 @@ set -euo pipefail
 run () {
   export PATH="${PATH}:${HOME}/kcov/bin"
   mkdir build build-tests
+
   cd build
   cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_INSTALL_PREFIX=/usr/local .. || exit 64
   make || exit 64
   make install || exit 64
   cd ..
+
   cd build-tests
   cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../tests || exit 64
   make || exit 64

--- a/.github/workflows/osx-build.sh
+++ b/.github/workflows/osx-build.sh
@@ -13,7 +13,7 @@ run () {
   cd ..
 
   cd build-tests
-  cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../tests || exit 64
+  cmake ../tests || exit 64
   make || exit 64
   cd ..
 

--- a/.github/workflows/osx-build.sh
+++ b/.github/workflows/osx-build.sh
@@ -16,6 +16,10 @@ run () {
   cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../tests || exit 64
   make || exit 64
   cd ..
+
+  chmod u+x .github/workflows/test-executable.sh
+  kcov --include-pattern=test-executable.sh coverage .github/workflows/test-executable.sh
+  cat coverage/test-executable.sh/coverage.json
 }
 
 run "$@"

--- a/tests/tools/test_python.py
+++ b/tests/tools/test_python.py
@@ -1,7 +1,10 @@
+import shutil
 import unittest
 
 import libkcov
 from libkcov import cobertura
+
+skip_python2 = shutil.which("python2") is None
 
 
 class python_exit_status(libkcov.TestCase):
@@ -43,6 +46,7 @@ class python_can_set_legal_parser(libkcov.TestCase):
 
 
 class python2_can_set_legal_parser(libkcov.TestCase):
+    @unittest.skipIf(skip_python2, "python2 not available")
     def runTest(self):
         rv, o = self.do(
             self.kcov
@@ -145,6 +149,7 @@ class python3_coverage(PythonBase):
 
 
 class python2_coverage(PythonBase):
+    @unittest.skipIf(skip_python2, "python2 not available")
     def runTest(self):
         self.doTest("--python-parser=python2")
 


### PR DESCRIPTION
In the previous days I played with the CI, and found that the tests on MacOS actually works fine (after fixing some incorrect code).

Running tests for Linux armv7, aarch64, ppc64le and i386 instead result in several errors, so I will try to find the cause in a future PR.

## CHANGES

  - [x] ci: change uraimo/run-on-arch version to v2
    
    Instead of using the fixed version v2.6.0, use v2 so that updates are
    automatic.
    
    This may introduce bugs but it will also contain improvements.

  - [x] ci: set strategy.fail-fast to false
    
    Errors from other architectures are important.

  - [x] ci: use python3, instead of python in `ci-run-tests.sh`
    
    Using python3 will avoid unspecified behavior when using Python on
    different systems, causing an error when trying to run the tests.

    See https://peps.python.org/pep-0394/

  - [x] tests: skip tests using python2, when not available
    
    This happens on MacOs.
    
    See https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes

  - [x] ci: make {{os}}-build.sh files more readable
    
    Separate each code block, so that each action is easy to read.

  - [x] ci: show coverage on `test_executable.sh` on MacOs
    
    It is done on Linux and FreeBSD; do the same with MacOs.

  - [x] ci: remove -DCMAKE_INSTALL_PREFIX when building tests
    
    The tests binaries are never installed.

  - [x] ci: enable tests for MacOS.
    
    It works correctly.

## NOTES

I added an additional code block in `osx-build.sh`, since it was done for Linux and FreeBSD.
However I'm not sure what is the purpose of this, since the result should be checked manually.

## TODO

I tried to run tests without using `sudo`, but on Linux/amd64 I got the error
```console
ERROR: runTest (test_compiled.debuglink)
....
        FileNotFoundError: [Errno 2] No such file or directory: 'build-tests/main-tests-debug-file'
```

On my system I never encountered this error.

On MacOs instead the test runner stopped after a few tests, maybe cause a deadlock.