### PR TITLE
Issue #437: Fixes for --collect-only/--report-only

### DIFF
--- a/doc/vscode.md
+++ b/doc/vscode.md
@@ -8,7 +8,7 @@ extension when the coverage changes.
 
 To produce this output, just run
 
-```
+```sh
 kcov --cobertura-only [other options] /path/to/your/folder/.vscode /path/to/the/binary
 ```
 

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -493,11 +493,26 @@ public:
 			setKey("binary-path", tmp.first);
 			binaryName = tmp.second;
 
+			setKey("binary-name", binaryName);
+
 			if (!keyAsInt("cobertura-only"))
 			{
-				setKey("target-directory",
-						fmt("%s/%s.%08zx", outDirectory.c_str(), binaryName.c_str(),
-								(size_t)hash_file(get_real_path(binaryPath))));
+					IFileParser *parser = IParserManager::getInstance().matchParser(binaryPath);
+
+				if (parser && (parser->getParserType() == "bash" ||
+					parser->getParserType() == "python"))
+				{
+					// Use the path as the hash for non-compiled languages
+					setKey("target-directory",
+							fmt("%s/%s.%08zx", keyAsString("out-directory").c_str(), keyAsString("binary-name").c_str(),
+							std::hash<std::string>()(keyAsString("binary-name").c_str())));
+				}
+				else
+				{
+					setKey("target-directory",
+							fmt("%s/%s.%08zx", outDirectory.c_str(), binaryName.c_str(),
+									(size_t)hash_file(get_real_path(binaryPath))));
+				}
 			}
 			else
 			{
@@ -510,8 +525,6 @@ public:
 				error("report-only selected, but the target directory %s does not exist\n", keyAsString("target-directory").c_str());
 				return usage();
 			}
-
-			setKey("binary-name", binaryName);
 
 			if (keyAsString("command-name") == "")
 				setKey("command-name", binaryName);

--- a/src/main.cc
+++ b/src/main.cc
@@ -224,16 +224,6 @@ static int runKcov(IConfiguration::RunMode_t runningMode)
 		return 1;
 	}
 
-	if ((parser->getParserType() == "bash" ||
-		parser->getParserType() == "python") &&
-		!conf.keyAsInt("cobertura-only"))
-	{
-		// Use the path as the hash for non-compiled languages
-		conf.setKey("target-directory",
-				fmt("%s/%s.%08zx", conf.keyAsString("out-directory").c_str(), conf.keyAsString("binary-name").c_str(),
-				std::hash<std::string>()(conf.keyAsString("binary-name").c_str())));
-	}
-
 	// Match and create an engine
 	IEngineFactory::IEngineCreator &engineCreator =
 			IEngineFactory::getInstance().matchEngine(file);


### PR DESCRIPTION
For bash, this corrects the name mismatch between --collect-only/--report-only. It doesn't work even then, and I don't think it ever has.

For Mach-O (MacOS binaries) it corrects --report-only.