### PR TITLE
Add cmake to Ubuntu build packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ Ubuntu / Debian
 Install
 
 ```sh
-apt-get install binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev
+apt-get install binutils-dev cmake libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev
 ```
 
 Fedora / Centos / RHEL


### PR DESCRIPTION
`cmake` is not available by default on a minimal installation of Ubuntu. Add it to the list of packages to install to build kcov.