### PR TITLE
fix: silence git stderr for coveralls writer

### DIFF
--- a/src/writers/coveralls-writer.cc
+++ b/src/writers/coveralls-writer.cc
@@ -21,12 +21,12 @@
 
 #include "writer-base.hh"
 
-static std::vector<std::string> run_command(const std::string& command)
+static std::vector<std::string> run_command_silent_stderr(const std::string& command)
 {
 	std::array<char, 128> buffer;
 	std::vector<std::string> stdoutLines;
 
-	FILE* pipe = popen(command.c_str(), "r");
+	FILE* pipe = popen((command + " 2>/dev/null").c_str(), "r");
 
 	if (!pipe) {
 		std::cerr << "[run_command] Failed calling popen()\n";
@@ -147,7 +147,7 @@ public:
 
 	void onStartup()
 	{
-        m_gitInfo = getGitInfoMap();
+		m_gitInfo = getGitInfoMap();
 	}
 
 	void onStop()
@@ -213,7 +213,7 @@ public:
 		}
 
 		if (!m_gitInfo.empty() && !m_gitInfo["gitRootPath"].empty())
-            strip_path = m_gitInfo["gitRootPath"] + "/";
+			strip_path = m_gitInfo["gitRootPath"] + "/";
 
 		unsigned int filesLeft = m_files.size();
 		for (FileMap_t::const_iterator it = m_files.begin();
@@ -283,11 +283,11 @@ private:
 
 	std::unordered_map<std::string, std::string> getGitInfoMap()
 	{
-	    std::unordered_map<std::string, std::string> gitInfoMap;
+		std::unordered_map<std::string, std::string> gitInfoMap;
 
-		auto optionalGitInfo = run_command("git log -1 --pretty=format:'%H%n%aN%n%aE%n%cN%n%cE%n%s'");
-		auto optionalGitBranch = run_command("git rev-parse --abbrev-ref HEAD");
-		auto optionalGitRootPath = run_command("git rev-parse --show-toplevel");
+		auto optionalGitInfo = run_command_silent_stderr("git log -1 --pretty=format:'%H%n%aN%n%aE%n%cN%n%cE%n%s'");
+		auto optionalGitBranch = run_command_silent_stderr("git rev-parse --abbrev-ref HEAD");
+		auto optionalGitRootPath = run_command_silent_stderr("git rev-parse --show-toplevel");
 		if (6 != optionalGitInfo.size())
 		    return gitInfoMap;
 

--- a/src/writers/coveralls-writer.cc
+++ b/src/writers/coveralls-writer.cc
@@ -21,12 +21,16 @@
 
 #include "writer-base.hh"
 
-static std::vector<std::string> run_command_silent_stderr(const std::string& command)
+static std::vector<std::string> run_command(const std::string& command, bool stderr_enabled = true)
 {
 	std::array<char, 128> buffer;
 	std::vector<std::string> stdoutLines;
 
-	FILE* pipe = popen((command + " 2>/dev/null").c_str(), "r");
+	std::string full_command = command;
+	if (!stderr_enabled)
+		full_command += " 2>/dev/null";
+
+	FILE* pipe = popen(full_command.c_str(), "r");
 
 	if (!pipe) {
 		std::cerr << "[run_command] Failed calling popen()\n";
@@ -285,11 +289,16 @@ private:
 	{
 		std::unordered_map<std::string, std::string> gitInfoMap;
 
-		auto optionalGitInfo = run_command_silent_stderr("git log -1 --pretty=format:'%H%n%aN%n%aE%n%cN%n%cE%n%s'");
-		auto optionalGitBranch = run_command_silent_stderr("git rev-parse --abbrev-ref HEAD");
-		auto optionalGitRootPath = run_command_silent_stderr("git rev-parse --show-toplevel");
+		// check whether we are inside a git work tree before collecting git metadata
+		auto insideWorkTree = run_command("git rev-parse --is-inside-work-tree", false);
+		if (insideWorkTree.size() != 1 || insideWorkTree[0] != "true")
+			return gitInfoMap;
+
+		auto optionalGitInfo = run_command("git log -1 --pretty=format:'%H%n%aN%n%aE%n%cN%n%cE%n%s'");
+		auto optionalGitBranch = run_command("git rev-parse --abbrev-ref HEAD");
+		auto optionalGitRootPath = run_command("git rev-parse --show-toplevel");
 		if (6 != optionalGitInfo.size())
-		    return gitInfoMap;
+			return gitInfoMap;
 
 		gitInfoMap["commitHash"] = optionalGitInfo[0];
 		gitInfoMap["authorName"] = optionalGitInfo[1];


### PR DESCRIPTION
A recent change that introduced `git` metadata collection to the `coveralls` writer leads to significant error logging in cases where the `kcov` invocation doesn't occur inside a `git` repository. 

Since one cannot opt out of either the `coveralls` output or the `git` metadata collection, I think it is fair to silence the `stderr` output of `git`, given that there is no error handling in the code, besides not collecting metadata in such cases. However, disabling `stderr` output for all `git` invocations could mask relevant error messages.

So, I added a check to see whether `kcov` executes inside the git work tree (which is silent on `stderr`) and only run the metadata collection if that is true.

(+ minor spaces to tabs normalization on related lines)