### PR TITLE
fix: Preserve signal exit code when child process exits after crash

### DIFF
--- a/src/collector.cc
+++ b/src/collector.cc
@@ -18,8 +18,8 @@ class Collector : public ICollector,
 {
 public:
 	Collector(IFileParser &fileParser, IEngine &engine, IFilter &filter) :
-			m_fileParser(fileParser), m_engine(engine), m_exitCode(-1), m_filter(
-					filter)
+			m_fileParser(fileParser), m_engine(engine), m_exitCode(-1),
+					m_signalExit(false), m_filter(filter)
 	{
 		m_fileParser.registerLineListener(*this);
 	}
@@ -136,6 +136,7 @@ private:
 #endif
 						);
 			m_exitCode = ev.data;
+			m_signalExit = true;
 			break;
 
 		case ev_exit_first_process:
@@ -154,7 +155,8 @@ private:
 			m_exitCode = ev.data;
 			break;
 		case ev_exit:
-			m_exitCode = ev.data;
+			if (!m_signalExit)
+				m_exitCode = ev.data;
 			break;
 		case ev_breakpoint:
 			for (ListenerList_t::const_iterator it = m_listeners.begin();
@@ -187,6 +189,7 @@ private:
 	ListenerList_t m_listeners;
 	EventTickListenerList_t m_eventTickListeners;
 	int m_exitCode;
+	bool m_signalExit;
 
 	IFilter &m_filter;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ add_library(shared_library SHARED
 add_executable(main-tests ${main_tests_SRCS})
 add_executable(fork ${fork_SRCS})
 add_executable(fork_no_wait ${fork_no_wait_SRCS})
+add_executable(fork_crash fork/fork-crash.c)
 add_executable(vfork fork/vfork.c)
 add_executable(signals ${signals_SRCS})
 

--- a/tests/fork/fork-crash.c
+++ b/tests/fork/fork-crash.c
@@ -1,0 +1,27 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <signal.h>
+
+int main(int argc, const char *argv[])
+{
+	pid_t child;
+
+	child = fork();
+	if (child < 0) {
+		fprintf(stderr, "fork failed!\n");
+		return -1;
+	}
+
+	if (child == 0) {
+		printf("In child, waiting\n");
+		sleep(5);
+		printf("Wait done\n");
+		return 0;
+	}
+
+	printf("Parent %d. Will crash\n", getpid());
+	raise(SIGSEGV);
+
+	return 0;
+}

--- a/tests/tools/test_compiled.py
+++ b/tests/tools/test_compiled.py
@@ -210,6 +210,16 @@ class signals_self(SignalsBase):
         self.doTest()
 
 
+class fork_crash(libkcov.TestCase):
+    @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX")
+    def runTest(self):
+        rv, o = self.do(
+            self.kcov + " " + self.outbase + "/kcov " + self.binaries + "/fork_crash",
+            False,
+        )
+        assert rv != 0
+
+
 class signals_crash(libkcov.TestCase):
     @unittest.skipIf(sys.platform.startswith("darwin"), "Not for OSX (macho-parser for now)")
     def runTest(self):
@@ -218,12 +228,14 @@ class signals_crash(libkcov.TestCase):
             False,
         )
         assert b"kcov: Process exited with signal 11" in o
+        assert rv == 11
 
         rv, o = self.do(
             self.kcov + " " + self.outbase + "/kcov " + self.binaries + "/signals abrt self",
             False,
         )
         assert b"kcov: Process exited with signal 6" in o
+        assert rv == 6
 
 
 class collect_and_report_only(libkcov.TestCase):


### PR DESCRIPTION
When a multi-process program crashes, kcov sometimes exits with zero instead of the signal number. When a child process exits normally _after_ the parent's signal exit has already been recorded, the child's `ev_exit` event overwrites the parent's exit code.

=> Keep track when `ev_signal_exit` sets the exit code so that subsequent `ev_exit` events from child processes cannot overwrite it.

See also:
- getsentry/sentry-native#1596
- getsentry/sentry-native#1419

Note: The `fork_crash` test relies on the child process outliving the parent's crash. The child sleeps for an arbitrary 5 seconds, which is way more than enough locally, but the test is not 100% guaranteed to reproduce the bug in loaded CI environments. Also, the `signals_crash` exit code assertions are merely documenting the expected single-process signal exit code behavior rather than guarding against this specific regression.