### PR TITLE
Issue #497: widen getAligned to 64-bit in the mach engine

### DIFF
--- a/src/engines/mach-engine.cc
+++ b/src/engines/mach-engine.cc
@@ -69,8 +69,8 @@ constexpr auto regs_flavor = ARM_THREAD_STATE64;
 #endif
 
 
-constexpr uint32_t
-getAligned(uint32_t addr)
+constexpr unsigned long
+getAligned(unsigned long addr)
 {
     return (addr / sizeof(uint32_t)) * sizeof(uint32_t);
 }


### PR DESCRIPTION
Fixes the 64-bit address truncation in #497.

`getAligned` in the mach engine took and returned `uint32_t`, truncating breakpoint addresses above the 4 GB macOS image base and producing an out-of-range shift in `arch_setupBreakpoint` (undefined behaviour; aborts under `-fsanitize=undefined`). Widen it to `unsigned long`, matching the `unsigned long` callers and the Linux ptrace engine's identical helper.

Non-sanitized builds are unaffected — the oversized shift is masked by the hardware shift count — so this only removes the UB and the UBSan abort.
